### PR TITLE
Add detailed documentation/examples for each exported runtime.

### DIFF
--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -130,7 +130,43 @@ runtimeLoop baseRuntimeRequest staticContext fn = do
     Left e  -> sendEventError baseRuntimeRequest reqIdBS e
 
 --TODO: Revisit all names before we put them under contract
--- | For any monad that supports IO/catch/Reader LambdaContext
+-- | For any monad that supports IO/catch/Reader LambdaContext.
+--
+-- Use this if you need caching behavours or are comfortable
+-- manipulating monad transformers and want full control over
+-- your monadic interface.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Context (LambdaContext(..))
+--     import AWS.Lambda.Runtime (mRuntimeWithContext)
+--     import Control.Monad.Reader (ReaderT, ask)
+--     import Control.Monad.State.Lazy (StateT, runStateT, get, put)
+--     import Data.Aeson (FromJSON)
+--     import Data.Text (unpack)
+--     import System.Environment (getEnv)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> StateT Int (ReaderT LambdaContext IO String)
+--     myHandler Named { name } = do
+--       LambdaContext { functionName } <- ask
+--       greeting <- getEnv \"GREETING\"
+--
+--       greetingCount <- get
+--       put $ greetingCount + 1
+--
+--       return $ greeting ++ name ++ " (" ++ show greetingCount ++ ") from " ++ unpack functionName ++ "!"
+--
+--     main :: IO ()
+--     main = runStateT (mRuntimeWithContext myHandler) 0
+-- @
 mRuntimeWithContext :: (HasLambdaContext r, MonadCatch m, MonadReader r m, MonadIO m, FromJSON event, ToJSON result) =>
   (event -> m result) -> m ()
 mRuntimeWithContext fn = do
@@ -151,11 +187,73 @@ readerTRuntimeWithContext :: ReaderT LambdaContext m a -> m a
 readerTRuntimeWithContext = flip runReaderT defConfig
 
 -- | For functions that can read the lambda context and use IO within the same monad.
+--
+-- Use this for handlers that need any form of side-effect such as reading
+-- environment variables or making network requests, and prefer to access the
+-- AWS Lambda Context in the same monad.
+-- However, do not use this runtime if you need stateful (caching) behaviors.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Context (LambdaContext(..))
+--     import AWS.Lambda.Runtime (readerTRuntime)
+--     import Control.Monad.Reader (ReaderT, ask)
+--     import Data.Aeson (FromJSON)
+--     import Data.Text (unpack)
+--     import System.Environment (getEnv)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> ReaderT LambdaContext IO String
+--     myHandler Named { name } = do
+--       LambdaContext { functionName } <- ask
+--       greeting <- getEnv \"GREETING\"
+--       return $ greeting ++ name ++ " from " ++ unpack functionName ++ "!"
+--
+--     main :: IO ()
+--     main = readerTRuntime myHandler
+-- @
 readerTRuntime :: (FromJSON event, ToJSON result) =>
   (event -> ReaderT LambdaContext IO result) -> IO ()
 readerTRuntime = readerTRuntimeWithContext .  mRuntimeWithContext
 
--- | For functions with IO that can fail in a pure way (or via throwM).
+-- | For functions with IO that can fail in a pure way (or via throw).
+--
+-- Use this for handlers that need any form of side-effect such as reading
+-- environment variables or making network requests, and also need the
+-- AWS Lambda Context as input.
+-- However, do not use this runtime if you need stateful (caching) behaviors.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Context (LambdaContext(..))
+--     import AWS.Lambda.Runtime (ioRuntimeWithContext)
+--     import Data.Aeson (FromJSON)
+--     import Data.Text (unpack)
+--     import System.Environment (getEnv)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: LambdaContext -> Named -> IO String
+--     myHandler (LambdaContext { functionName }) (Named { name }) = do
+--       greeting <- getEnv \"GREETING\"
+--       return $ greeting ++ name ++ " from " ++ unpack functionName ++ "!"
+--
+--     main :: IO ()
+--     main = ioRuntimeWithContext myHandler
+-- @
 ioRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> IO (Either String result)) -> IO ()
 ioRuntimeWithContext fn = readerTRuntime (\event -> do
@@ -166,31 +264,162 @@ ioRuntimeWithContext fn = readerTRuntime (\event -> do
     Right x -> return x
  )
 
--- | For functions with IO that can fail in a pure way (or via throwM).
+-- | For functions with IO that can fail in a pure way (or via throw).
+--
+-- Use this for handlers that need any form of side-effect such as reading
+-- environment variables or making network requests.
+-- However, do not use this runtime if you need stateful (caching) behaviors.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (ioRuntime)
+--     import Data.Aeson (FromJSON)
+--     import System.Environment (getEnv)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> IO String
+--     myHandler (Named { name }) = do
+--       greeting <- getEnv \"GREETING\"
+--       return $ greeting ++ name
+--
+--     main :: IO ()
+--     main = ioRuntime myHandler
+-- @
 ioRuntime :: (FromJSON event, ToJSON result) =>
   (event -> IO (Either String result)) -> IO ()
 ioRuntime fn = ioRuntimeWithContext wrapped
     where wrapped _ e = fn e
 
 -- | For pure functions that can still fail.
+--
+-- Use this for simple handlers that just translate input to output without side-effects,
+-- but can fail and need the AWS Lambda Context as input.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Context (LambdaContext(..))
+--     import AWS.Lambda.Runtime (fallibleRuntimeWithContext)
+--     import Data.Aeson (FromJSON)
+--     import Data.Text (unpack)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: LambdaContext -> Named -> Either String String
+--     myHandler (LambdaContext { functionName }) (Named { name }) =
+--       if name == \"World\" then
+--         Right "Hello, World from " ++ unpack functionName ++ "!"
+--       else
+--         Left "Can only greet the world."
+--
+--     main :: IO ()
+--     main = fallibleRuntimeWithContext myHandler
+-- @
 fallibleRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> Either String result) -> IO ()
 fallibleRuntimeWithContext fn = ioRuntimeWithContext wrapped
   where wrapped c e = return $ fn c e
 
 -- | For pure functions that can still fail.
+--
+-- Use this for simple handlers that just translate input to output without side-effects,
+-- but can fail.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (fallibleRuntime)
+--     import Data.Aeson (FromJSON)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> Either String String
+--     myHandler (Named { name }) =
+--       if name == \"World\" then
+--         Right "Hello, World!"
+--       else
+--         Left "Can only greet the world."
+--
+--     main :: IO ()
+--     main = fallibleRuntime myHandler
+-- @
 fallibleRuntime :: (FromJSON event, ToJSON result) =>
   (event -> Either String result) -> IO ()
 fallibleRuntime fn = fallibleRuntimeWithContext wrapped
   where
     wrapped _ e = fn e
 
--- | For pure functions that can never fail.
+-- | For pure functions that can never fail that also need access to the context.
+--
+-- Use this for simple handlers that just translate input to output without side-effects,
+-- but that need the AWS Lambda Context as input.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Context (LambdaContext(..))
+--     import AWS.Lambda.Runtime (pureRuntimeWithContext)
+--     import Data.Aeson (FromJSON)
+--     import Data.Text (unpack)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: LambdaContext -> Named -> String
+--     myHandler (LambdaContext { functionName }) (Named { name }) =
+--       "Hello, " ++ name ++ " from " ++ unpack functionName ++ "!"
+--
+--     main :: IO ()
+--     main = pureRuntimeWithContext myHandler
+-- @
 pureRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> result) -> IO ()
 pureRuntimeWithContext fn = fallibleRuntimeWithContext wrapped
   where wrapped c e = Right $ fn c e
 
 -- | For pure functions that can never fail.
+--
+-- Use this for simple handlers that just translate input to output without side-effects.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (pureRuntime)
+--     import Data.Aeson (FromJSON)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> String
+--     myHandler Named { name } = "Hello, " ++ name ++ "!"
+--
+--     main :: IO ()
+--     main = pureRuntime myHandler
+-- @
 pureRuntime :: (FromJSON event, ToJSON result) => (event -> result) -> IO ()
 pureRuntime fn = fallibleRuntime (Right . fn)


### PR DESCRIPTION
Should look nice when run through haddock :)

Hard to be positive that these are 100% accurate, being in the docs and all, but I was pretty thorough.  I added all the imports explicitly because I always find it a challenge in documentation examples when I don't know where key things come from.  Wanted the examples to be something that you could copy into a file and have work immediately.