### PR TITLE
Bump LTS minor version and add revision to PVP bounds

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.21
+resolver: lts-12.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -68,4 +68,4 @@ docker:
   enable: true
 
 # https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds
-pvp-bounds: both
+pvp-bounds: both-revision


### PR DESCRIPTION
It turns out that without that flag we will set bounds on our packages
that will break on newer LTS versions. Rather than risk having `hal`
removed from Stackage for versions that are _likely_ fine, we'll enable
this flag and add more LTS versions to Travis builds when they're
working :)

Once this is merged I'll cut another bug fix release and re-submit to Stackage.