### PR TITLE
Use combinators to simplify…

### DIFF
--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -1,10 +1,14 @@
 {-|
 Module      : AWS.Lambda.Combinators
-Description : Function transformers that can be used to adapt the base runtime into more useful interfaces.
+Description : Function transformers that can be used to adapt the base runtime into other useful interfaces.
 Copyright   : (c) Nike, Inc., 2018
 License     : BSD3
 Maintainer  : nathan.fairhurst@nike.com, fernando.freire@nike.com
 Stability   : stable
+
+These combinators are for those who need to peek below the abstraction of the basic runtimes, for whatever reason.
+
+They map functions (instead of values) to turn basic handlers into handlers compatible with the base runtime.  These combinators allow us to expose functionality across many dimensions in an abstract way.  It also allows simple building blocks for those who need to "get in the middle" or adapt the basic runtimes in new ways without rebuilding everything from the ground up.
 -}
 
 module AWS.Lambda.Combinators (
@@ -18,27 +22,164 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Reader   (MonadReader, ask)
 
 
--- Helper for converting an either into a monad/exception
+-- Helper for converting an either result into a monad/exception
 dropEither :: Monad m => Either String a -> m a
 dropEither = \case 
      Left e  -> error e
      Right x -> return x
 
+
+-- | Upgrades a handler that uses the `IO` monad with an `Either` inside into a
+-- base runtime handler.
+--
+-- In the example below, we reconstruct 'AWS.Lambda.Runtime.ioRuntimeWithContext'
+-- without actually using it. The 'AWS.Lambda.Runtime.readerTRuntime' expects
+-- a handler in the form of @event -> ReaderT LambdaContext IO result@
+-- (ignoring constraints).  By composing it with `withIOInterface` we get a new runtime which
+-- expects a function in the form of @LambdaContext -> event -> IO result@
+-- which matches that of `myHandler`.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (readerTRuntime)
+--     import AWS.Lambda.Combinators (withIOInterface)
+--     import Data.Aeson (FromJSON)
+--     import System.Environment (getEnv)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> IO String
+--     myHandler (Named { name }) = do
+--       greeting <- getEnv \"GREETING\"
+--       return $ greeting ++ name
+--
+--     main :: IO ()
+--     main = (readerTRuntime . withIOInterface) myHandler
+-- @
 withIOInterface :: (MonadReader c m, MonadIO m) => (c -> b -> IO (Either String a)) -> (b -> m a)
 withIOInterface fn event = do
   config <- ask
   result <- liftIO $ fn config event
   dropEither result
 
+-- | Upgrades a handler that accepts 'AWS.Lambda.Context.LambdaContext' and
+-- an event to return a value inside an `Either` inside into a base runtime handler.
+--
+-- In the example below, we reconstruct 'AWS.Lambda.Runtime.fallableRuntimeWithContext'
+-- without actually using it.  The 'AWS.Lambda.Runtime.readerTRuntime' expects a handler
+-- in the form of @event -> ReaderT LambdaContext IO result@ (ignoring constraints).
+-- By composing it with `withFallableInterface` we get a new runtime which
+-- expects a function in the form of @LambdaContext -> event -> Either String result@
+-- which matches that of `myHandler`.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (readerTRuntime)
+--     import AWS.Lambda.Combinators (withFallableInterface)
+--     import Data.Aeson (FromJSON)
+--     import System.Environment (getEnv)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: LambdaContext -> Named -> Either String String
+--     myHandler (LambdaContext { functionName }) (Named { name }) =
+--       if name == \"World\" then
+--         Right "Hello, World from " ++ unpack functionName ++ "!"
+--       else
+--         Left "Can only greet the world."
+--
+--     main :: IO ()
+--     main = (readerTRuntime . withFallableInterface) myHandler
+-- @
 withFallableInterface :: MonadReader c m => (c -> b -> Either String a) -> b -> m a
 withFallableInterface fn event = do
   config <- ask
   dropEither $ fn config event
 
+-- | This combinator takes a handler that accepts both an event and
+-- 'AWS.Lambda.Context.LambdaContext' and converts it into a handler that is
+-- compatible with the base monadic runtime.
+--
+-- In the example below, we reconstruct 'AWS.Lambda.Runtime.pureRuntimeWithContext'
+-- without actually using it.
+-- The 'AWS.Lambda.Runtime.readerTRuntime' expects a handler in the form of
+-- @event -> ReaderT LambdaContext IO result@ (ignoring constraints).
+-- By composing it with `withPureInterface` we get a new runtime which
+-- expects a function in the form of @LambdaContext -> event -> result@
+-- which matches that of `myHandler`.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (readerTRuntime)
+--     import AWS.Lambda.Combinators (withPureInterface)
+--     import Data.Aeson (FromJSON)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: LambdaContext -> Named -> String
+--     myHandler (LambdaContext { functionName }) (Named { name }) =
+--       "Hello, " ++ name ++ " from " ++ unpack functionName ++ "!"
+--
+--     main :: IO ()
+--     main = (readerTRuntime . withPureInterface) myHandler
+-- @
 withPureInterface :: MonadReader c m => (c -> b -> a) -> b -> m a
 withPureInterface fn event = do
   config <- ask
   return $ fn config event
 
-withoutContext :: (a -> b) -> (c -> a -> b)
+-- | An alias of 'const', this upgrades a handler that does not accept
+-- 'AWS.Lambda.Context.LambdaContext' as its first curried argument to one that does.
+--
+-- This allows us to use other combinators to construct a lambda runtime that accepts
+-- a handler that ignores 'AWS.Lambda.Context.LambdaContext'.
+--
+-- In the example below, we reconstruct 'AWS.Lambda.Runtime.pureRuntime' without actually using it.
+-- The 'AWS.Lambda.Runtime.readerTRuntime' expects a handler in the form of
+-- @event -> ReaderT LambdaContext IO result@ (ignoring constraints).
+-- By composing it with `withPureInterface` we get a new runtime which
+-- expects a function in the form of @LambdaContext -> event -> result@,
+-- And then finally we also compose `withoutContext` so it accepts the signature
+-- @event -> result@ which matches that of `myHandler`.
+--
+-- @
+--     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+--
+--     module Main where
+--
+--     import AWS.Lambda.Runtime (readerTRuntime)
+--     import AWS.Lambda.Combinators (withPureInterface, withoutContext)
+--     import Data.Aeson (FromJSON)
+--
+--     data Named = {
+--       name :: String
+--     } deriving Generic
+--     instance FromJSON Named
+--
+--     myHandler :: Named -> String
+--     myHandler (Named { name }) =
+--       "Hello, " ++ name
+--
+--     main :: IO ()
+--     main = (readerTRuntime . withPureInterface . withoutContext) myHandler
+-- @
+withoutContext :: a -> b -> a
 withoutContext = const

--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -13,7 +13,7 @@ They map functions (instead of values) to turn basic handlers into handlers comp
 
 module AWS.Lambda.Combinators (
     withIOInterface,
-    withFallableInterface,
+    withFallibleInterface,
     withPureInterface,
     withoutContext
 ) where
@@ -71,10 +71,10 @@ withIOInterface fn event = do
 -- | Upgrades a handler that accepts 'AWS.Lambda.Context.LambdaContext' and
 -- an event to return a value inside an `Either` inside into a base runtime handler.
 --
--- In the example below, we reconstruct 'AWS.Lambda.Runtime.fallableRuntimeWithContext'
+-- In the example below, we reconstruct 'AWS.Lambda.Runtime.fallibleRuntimeWithContext'
 -- without actually using it.  The 'AWS.Lambda.Runtime.readerTRuntime' expects a handler
 -- in the form of @event -> ReaderT LambdaContext IO result@ (ignoring constraints).
--- By composing it with `withFallableInterface` we get a new runtime which
+-- By composing it with `withFallibleInterface` we get a new runtime which
 -- expects a function in the form of @LambdaContext -> event -> Either String result@
 -- which matches that of `myHandler`.
 --
@@ -84,7 +84,7 @@ withIOInterface fn event = do
 --     module Main where
 --
 --     import AWS.Lambda.Runtime (readerTRuntime)
---     import AWS.Lambda.Combinators (withFallableInterface)
+--     import AWS.Lambda.Combinators (withFallibleInterface)
 --     import Data.Aeson (FromJSON)
 --     import System.Environment (getEnv)
 --
@@ -101,10 +101,10 @@ withIOInterface fn event = do
 --         Left "Can only greet the world."
 --
 --     main :: IO ()
---     main = (readerTRuntime . withFallableInterface) myHandler
+--     main = (readerTRuntime . withFallibleInterface) myHandler
 -- @
-withFallableInterface :: MonadReader c m => (c -> b -> Either String a) -> b -> m a
-withFallableInterface fn event = do
+withFallibleInterface :: MonadReader c m => (c -> b -> Either String a) -> b -> m a
+withFallibleInterface fn event = do
   config <- ask
   dropEither $ fn config event
 

--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -1,0 +1,44 @@
+{-|
+Module      : AWS.Lambda.Combinators
+Description : Function transformers that can be used to adapt the base runtime into more useful interfaces.
+Copyright   : (c) Nike, Inc., 2018
+License     : BSD3
+Maintainer  : nathan.fairhurst@nike.com, fernando.freire@nike.com
+Stability   : stable
+-}
+
+module AWS.Lambda.Combinators (
+    withIOInterface,
+    withFallableInterface,
+    withPureInterface,
+    withoutContext
+) where
+
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.Reader   (MonadReader, ask)
+
+
+-- Helper for converting an either into a monad/exception
+dropEither :: Monad m => Either String a -> m a
+dropEither = \case 
+     Left e  -> error e
+     Right x -> return x
+
+withIOInterface :: (MonadReader c m, MonadIO m) => (c -> b -> IO (Either String a)) -> (b -> m a)
+withIOInterface fn event = do
+  config <- ask
+  result <- liftIO $ fn config event
+  dropEither result
+
+withFallableInterface :: MonadReader c m => (c -> b -> Either String a) -> b -> m a
+withFallableInterface fn event = do
+  config <- ask
+  dropEither $ fn config event
+
+withPureInterface :: MonadReader c m => (c -> b -> a) -> b -> m a
+withPureInterface fn event = do
+  config <- ask
+  return $ fn config event
+
+withoutContext :: (a -> b) -> (c -> a -> b)
+withoutContext = const

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -16,10 +16,12 @@ module AWS.Lambda.Context (
   LambdaContext(..),
   HasLambdaContext(..),
   defConfig,
-  getRemainingTime
+  getRemainingTime,
+  runReaderTLambdaContext
 ) where
 
 import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.Reader   (ReaderT, runReaderT)
 import           Data.Aeson             (FromJSON, ToJSON)
 import           Data.Map               (Map)
 import           Data.Text              (Text)
@@ -83,3 +85,7 @@ instance HasLambdaContext LambdaContext where
 
 instance DefConfig LambdaContext where
   defConfig = LambdaContext "" "" 0 "" "" "" "" "" (posixSecondsToUTCTime 0) Nothing Nothing
+
+-- | Helper for using arbitrary monads with only the LambdaContext in its Reader
+runReaderTLambdaContext :: ReaderT LambdaContext m a -> m a
+runReaderTLambdaContext = flip runReaderT defConfig

--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -31,7 +31,7 @@ module AWS.Lambda.Runtime (
 import           AWS.Lambda.RuntimeClient (getBaseRuntimeRequest, getNextEvent,
                                            sendEventError, sendEventSuccess, sendInitError)
 import           AWS.Lambda.Combinators   (withIOInterface,
-                                           withFallableInterface,
+                                           withFallibleInterface,
                                            withPureInterface,
                                            withoutContext)
 import           AWS.Lambda.Context       (LambdaContext(..), HasLambdaContext(..), runReaderTLambdaContext)
@@ -331,7 +331,7 @@ ioRuntime = readerTRuntime . withIOInterface . withoutContext
 -- @
 fallibleRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> Either String result) -> IO ()
-fallibleRuntimeWithContext = readerTRuntime . withFallableInterface
+fallibleRuntimeWithContext = readerTRuntime . withFallibleInterface
 
 -- | For pure functions that can still fail.
 --
@@ -363,7 +363,7 @@ fallibleRuntimeWithContext = readerTRuntime . withFallableInterface
 -- @
 fallibleRuntime :: (FromJSON event, ToJSON result) =>
   (event -> Either String result) -> IO ()
-fallibleRuntime = readerTRuntime . withFallableInterface . withoutContext
+fallibleRuntime = readerTRuntime . withFallibleInterface . withoutContext
 
 -- | For pure functions that can never fail that also need access to the context.
 --

--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -7,6 +7,14 @@ Copyright   : (c) Nike, Inc., 2018
 License     : BSD3
 Maintainer  : nathan.fairhurst@nike.com, fernando.freire@nike.com
 Stability   : stable
+
+These are runtimes designed for AWS Lambda, which accept a handler and return
+an application that will retreive and execute events as long as a container
+continues to exist.
+
+Many of these runtimes use "AWS.Lambda.Combinators" under the hood.
+For those interested in peeking below the abstractions provided here,
+please refer to that module.
 -}
 
 module AWS.Lambda.Runtime (


### PR DESCRIPTION
… how unique handler interfaces are constructed.

Before merge we need to (at least) validate the names before they go under contract and add thorough documentation.