### PR TITLE
Add exponential backoff on retries and retry for up to one second.

### DIFF
--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -106,23 +106,26 @@ sendInitError baseRuntimeRequest e =
 
 -- Retry Helpers
 
-runtimeClientRetryTry' :: Int -> IO (Response a) -> IO (Either HttpException (Response a))
-runtimeClientRetryTry' 1 f = try f
-runtimeClientRetryTry' i f = do
-  resOrEx <- try f
-  let retry = threadDelay 500 >> runtimeClientRetryTry' (i - 1) f
-  case resOrEx of
-    Left (_ :: HttpException) -> retry
-    Right res ->
-      -- TODO: Explore this further.
-      -- Before ~July 22nd 2020 it seemed that if a next event request reached
-      -- the runtime before a new event was available that there would be a
-      -- network error.  After it appears that a 403 is returned.
-      if getResponseStatus res == status403 then retry
-      else return $ Right res
+runtimeClientRetryTry' :: Int -> Int -> IO (Response a) -> IO (Either HttpException (Response a))
+runtimeClientRetryTry' retries maxRetries f
+  | retries == maxRetries = try f
+  | otherwise = do
+    resOrEx <- try f
+    let retry =
+          threadDelay (500 * 2 ^ retries)
+            >> runtimeClientRetryTry' (retries + 1) maxRetries f
+    case resOrEx of
+      Left (_ :: HttpException) -> retry
+      Right res ->
+        -- TODO: Explore this further.
+        -- Before ~July 22nd 2020 it seemed that if a next event request reached
+        -- the runtime before a new event was available that there would be a
+        -- network error.  After it appears that a 403 is returned.
+        if getResponseStatus res == status403 then retry
+        else return $ Right res
 
 runtimeClientRetryTry :: IO (Response a) -> IO (Either HttpException (Response a))
-runtimeClientRetryTry = runtimeClientRetryTry' 3
+runtimeClientRetryTry = runtimeClientRetryTry' 0 10
 
 runtimeClientRetry :: IO (Response a) -> IO (Response a)
 runtimeClientRetry = fmap (either throw id) . runtimeClientRetryTry


### PR DESCRIPTION
This is just a good idea in general, allows much longer retry windows without risking over consumption of resources (potentially blocking the AWS runtime from doing what it needs to do).

This also should eliminate the final visible lingering effects of #54 given that the retry window is so much longer.

Solves #59 