### PR TITLE
Hide base runtime request in config

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ description: |
   This library uniquely supports different types of AWS Lambda Handlers for your
   needs/comfort with advanced Haskell. Instead of exposing a single function
   that constructs a Lambda, this library exposes many.
-version:             0.1.3
+version:             0.1.4
 github:              Nike-inc/hal
 license:             BSD3
 author:              Nike, Inc.

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -106,23 +106,26 @@ sendInitError baseRuntimeRequest e =
 
 -- Retry Helpers
 
-runtimeClientRetryTry' :: Int -> IO (Response a) -> IO (Either HttpException (Response a))
-runtimeClientRetryTry' 1 f = try f
-runtimeClientRetryTry' i f = do
-  resOrEx <- try f
-  let retry = threadDelay 500 >> runtimeClientRetryTry' (i - 1) f
-  case resOrEx of
-    Left (_ :: HttpException) -> retry
-    Right res ->
-      -- TODO: Explore this further.
-      -- Before ~July 22nd 2020 it seemed that if a next event request reached
-      -- the runtime before a new event was available that there would be a
-      -- network error.  After it appears that a 403 is returned.
-      if getResponseStatus res == status403 then retry
-      else return $ Right res
+runtimeClientRetryTry' :: Int -> Int -> IO (Response a) -> IO (Either HttpException (Response a))
+runtimeClientRetryTry' retries maxRetries f
+  | retries == maxRetries = try f
+  | otherwise = do
+    resOrEx <- try f
+    let retry =
+          threadDelay (500 * 2 ^ retries)
+            >> runtimeClientRetryTry' (retries + 1) maxRetries f
+    case resOrEx of
+      Left (_ :: HttpException) -> retry
+      Right res ->
+        -- TODO: Explore this further.
+        -- Before ~July 22nd 2020 it seemed that if a next event request reached
+        -- the runtime before a new event was available that there would be a
+        -- network error.  After it appears that a 403 is returned.
+        if getResponseStatus res == status403 then retry
+        else return $ Right res
 
 runtimeClientRetryTry :: IO (Response a) -> IO (Either HttpException (Response a))
-runtimeClientRetryTry = runtimeClientRetryTry' 3
+runtimeClientRetryTry = runtimeClientRetryTry' 0 10
 
 runtimeClientRetry :: IO (Response a) -> IO (Response a)
 runtimeClientRetry = fmap (either throw id) . runtimeClientRetryTry


### PR DESCRIPTION
This is a precursor to enabling a custom HTTP manager.  This refactor helps hide internal details of the runtime client, so that additions (such as the manager) can be made transparently to the consuming modules, making diffs smaller and backporting easier.

This is really just a start to the opportunities here (more hiding, monadic interfaces, etc), but it's a step in the right direction.