### PR TITLE
Use an explicit manager to eliminate request timeouts

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ description: |
   This library uniquely supports different types of AWS Lambda Handlers for your
   needs/comfort with advanced Haskell. Instead of exposing a single function
   that constructs a Lambda, this library exposes many.
-version:             0.1.4
+version:             0.1.5
 github:              Nike-inc/hal
 license:             BSD3
 author:              Nike, Inc.

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ description: |
   This library uniquely supports different types of AWS Lambda Handlers for your
   needs/comfort with advanced Haskell. Instead of exposing a single function
   that constructs a Lambda, this library exposes many.
-version:             0.4.3
+version:             0.4.4
 github:              Nike-inc/hal
 license:             BSD3
 author:              Nike, Inc.

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ description: |
   This library uniquely supports different types of AWS Lambda Handlers for your
   needs/comfort with advanced Haskell. Instead of exposing a single function
   that constructs a Lambda, this library exposes many.
-version:             0.2.2
+version:             0.2.3
 github:              Nike-inc/hal
 license:             BSD3
 author:              Nike, Inc.

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ description: |
   This library uniquely supports different types of AWS Lambda Handlers for your
   needs/comfort with advanced Haskell. Instead of exposing a single function
   that constructs a Lambda, this library exposes many.
-version:             0.3.2
+version:             0.3.3
 github:              Nike-inc/hal
 license:             BSD3
 author:              Nike, Inc.

--- a/package.yaml
+++ b/package.yaml
@@ -54,7 +54,10 @@ library:
   dependencies:
     - aeson
     - bytestring
+    - conduit
+    - conduit-extra
     - envy
+    - http-client
     - http-conduit
     - http-types
     - exceptions


### PR DESCRIPTION
HTTP Simple uses a global immutable manager with a 30s request timeout.  This makes good sense for a simple interface with sensible defaults, but timeouts don't make sense in a lambda context (the container will be frozen indefinitely) and causes unneeded churn and errors.

We also add some other reasonable manager settings like no proxy to prevent incorrect behavior based on global config and limiting maximum connections to ensure re-use and a light footprint.