### PR TITLE
Reduce envy usage for greater compatibility

### DIFF
--- a/.github/workflows/haskell_stack.yaml
+++ b/.github/workflows/haskell_stack.yaml
@@ -17,6 +17,10 @@ jobs:
           - lts-11
           - lts-12
           - lts-13
+          - lts-14
+          - lts-15
+          - lts-16
+          - lts-17
         experimental:
           - false
         include:

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d99d12f541c6f41234fdc2ae57170949f60f2136c4a634f557e11d20d843207f
+-- hash: fd1bbbf7692b6a9cd5e97b14652ceae0b867628e99600a30327e49175651e653
 
 name:           hal
 version:        0.4.6
@@ -56,7 +56,6 @@ library
     , conduit
     , conduit-extra
     , containers
-    , envy <2
     , exceptions
     , http-client
     , http-types

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fd1bbbf7692b6a9cd5e97b14652ceae0b867628e99600a30327e49175651e653
+-- hash: 7751f037bf113236504c075827a2a6c6c766569c3e09f84c4295d783a376602c
 
 name:           hal
 version:        0.4.6
@@ -56,6 +56,7 @@ library
     , conduit
     , conduit-extra
     , containers
+    , envy
     , exceptions
     , http-client
     , http-types

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ library:
     - bytestring
     - conduit
     - conduit-extra
+    - envy
     - http-client
     - http-types
     - exceptions

--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,6 @@ library:
     - bytestring
     - conduit
     - conduit-extra
-    - envy < 2
     - http-client
     - http-types
     - exceptions

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -29,7 +29,6 @@ import           Data.Time.Clock        (DiffTime, UTCTime,
                                          diffUTCTime, getCurrentTime)
 import           Data.Time.Clock.POSIX  (posixSecondsToUTCTime)
 import           GHC.Generics           (Generic)
-import           System.Envy            (DefConfig (..))
 
 data ClientApplication = ClientApplication
   { appTitle       :: Text,
@@ -83,8 +82,22 @@ class HasLambdaContext r where
 instance HasLambdaContext LambdaContext where
   withContext = const
 
-instance DefConfig LambdaContext where
-  defConfig = LambdaContext "" "" 0 "" "" "" "" "" (posixSecondsToUTCTime 0) Nothing Nothing
+-- TODO: This sticks around for both backwards compatibility and the lack of a
+-- clear and better alternative.  A clearer name (since we're no longer trying
+-- to satisfy the typeclass) would possibly be sufficient, but this entire flow
+-- is clunky.  Our reader's environment type needs to be consistent to keep the
+-- type of our monad consistent.  Since we don't have Context to start with,
+-- and then get it later, a Maybe seems appealing, but this is totally
+-- unhelpful as it's _always_ present by the time that the user's handler
+-- executes.
+--
+-- While it might make sense to simply runReaderT to inject this, so that the
+-- handler has the reader, but no other surrounding code does, this makes the
+-- current challenge of incorporating two different environments even harder.
+--
+-- Possibly, this should just be a synonym for `undefined`.
+defConfig :: LambdaContext
+defConfig = LambdaContext "" "" 0 "" "" "" "" "" (posixSecondsToUTCTime 0) Nothing Nothing
 
 -- | Helper for using arbitrary monads with only the LambdaContext in its Reader
 runReaderTLambdaContext :: ReaderT LambdaContext m a -> m a

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -84,10 +84,10 @@ instance HasLambdaContext LambdaContext where
   withContext = const
 
 -- TODO: This sticks around for backwards compatibility, and as a conevient-ish
--- way to runReaderTLambdaContext.  However, long term it would be better if
--- some of the ergonomics around Reader LambdaContext were improved.  For
--- example, there _is_ no LambdaContex until the event is received, but our
--- types don't effectively express that.
+-- way to runReaderTLambdaContext.  In the long term though, all runtimes based
+-- on the ReaderT LambdaContext approach will be removed, and this instance
+-- (and the dependency on its package, envy) can be dropped entirely on that
+-- breaking change.
 instance DefConfig LambdaContext where
   defConfig = LambdaContext "" "" 0 "" "" "" "" "" (posixSecondsToUTCTime 0) Nothing Nothing
 

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -84,10 +84,10 @@ instance HasLambdaContext LambdaContext where
   withContext = const
 
 -- TODO: This sticks around for backwards compatibility, and as a conevient-ish
--- way to runReaderTLambdaContext.  In the long term though, all runtimes based
--- on the ReaderT LambdaContext approach will be removed, and this instance
--- (and the dependency on its package, envy) can be dropped entirely on that
--- breaking change.
+-- way to runReaderTLambdaContext.  In the long term, all runtimes where the
+-- LambdaContext is (incorrectly) available outside of the request/response
+-- cycle will be removed.  This instance (and its dependent package, envy) can
+-- be dropped on that breaking change.
 instance DefConfig LambdaContext where
   defConfig = LambdaContext "" "" 0 "" "" "" "" "" (posixSecondsToUTCTime 0) Nothing Nothing
 

--- a/src/AWS/Lambda/Internal.hs
+++ b/src/AWS/Lambda/Internal.hs
@@ -35,12 +35,12 @@ data StaticContext = StaticContext
 
 getStaticContext :: IO StaticContext
 getStaticContext =
-  StaticContext <$> (pack <$> getEnv "FUNCTION_NAME") <*>
-  (pack <$> getEnv "FUNCTION_VERSION") <*>
-  ((fromMaybe (error "FUNCTION_MEMORY_SIZE was not an Int") . readMaybe) <$>
-   getEnv "FUNCTION_MEMORY_SIZE") <*>
-  (pack <$> getEnv "LOG_GROUP_NAME") <*>
-  (pack <$> getEnv "LOG_STREAM_NAME")
+  StaticContext <$> (pack <$> getEnv "AWS_LAMBDA_FUNCTION_NAME") <*>
+  (pack <$> getEnv "AWS_LAMBDA_FUNCTION_VERSION") <*>
+  ((fromMaybe (error "AWS_LAMBDA_FUNCTION_MEMORY_SIZE was not an Int") . readMaybe) <$>
+   getEnv "AWS_LAMBDA_FUNCTION_MEMORY_SIZE") <*>
+  (pack <$> getEnv "AWS_LAMBDA_LOG_GROUP_NAME") <*>
+  (pack <$> getEnv "AWS_LAMBDA_LOG_STREAM_NAME")
 
 data DynamicContext = DynamicContext
   { awsRequestId       :: Text,


### PR DESCRIPTION
Envy is a pretty handy library that does some pretty cool things--however, it's got a bit of churn in its versioning, and we really don't use _that_ much from it.  It makes more sense to simply replace the functionality so that broad support of LTSes is simpler.