### PR TITLE
Add mRuntimeWithContext' and mRuntime which will eventually replace t…

### DIFF
--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -13,12 +13,14 @@ They map functions (instead of values) to turn basic handlers into handlers comp
 
 module AWS.Lambda.Combinators (
     withIOInterface,
+    liftIOEither,
     withFallibleInterface,
     withPureInterface,
     withoutContext,
     withInfallibleParse
 ) where
 
+import           Control.Monad ((<=<))
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Reader   (MonadReader, ask)
 import           Data.Aeson             (FromJSON, parseJSON, Value)
@@ -31,6 +33,11 @@ dropEither = \case
      Left e  -> error e
      Right x -> return x
 
+
+-- | TODO
+liftIOEither :: MonadIO m => IO (Either String a) -> m a
+liftIOEither =
+  dropEither <=< liftIO
 
 -- | Upgrades a handler that uses the `IO` monad with an `Either` inside into a
 -- base runtime handler.
@@ -71,6 +78,7 @@ dropEither = \case
 --     main :: IO ()
 --     main = (readerTRuntime . withIOInterface) myHandler
 -- @
+{-# DEPRECATED withIOInterface "This combinator is useful when combined with the current mRuntimeWithContext, which is deprecated." #-}
 withIOInterface :: (MonadReader c m, MonadIO m) => (c -> b -> IO (Either String a)) -> (b -> m a)
 withIOInterface fn event = do
   config <- ask
@@ -114,6 +122,7 @@ withIOInterface fn event = do
 --     main :: IO ()
 --     main = (readerTRuntime . withFallibleInterface) myHandler
 -- @
+{-# DEPRECATED withFallibleInterface "This combinator is useful when combined with the current mRuntimeWithContext, which is deprecated." #-}
 withFallibleInterface :: MonadReader c m => (c -> b -> Either String a) -> b -> m a
 withFallibleInterface fn event = do
   config <- ask
@@ -155,6 +164,7 @@ withFallibleInterface fn event = do
 --     main :: IO ()
 --     main = (readerTRuntime . withPureInterface) myHandler
 -- @
+{-# DEPRECATED withPureInterface "This combinator is useful when combined with the current mRuntimeWithContext, which is deprecated." #-}
 withPureInterface :: MonadReader c m => (c -> b -> a) -> b -> m a
 withPureInterface fn event = do
   config <- ask

--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -13,14 +13,12 @@ They map functions (instead of values) to turn basic handlers into handlers comp
 
 module AWS.Lambda.Combinators (
     withIOInterface,
-    liftIOEither,
     withFallibleInterface,
     withPureInterface,
     withoutContext,
     withInfallibleParse
 ) where
 
-import           Control.Monad ((<=<))
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Reader   (MonadReader, ask)
 import           Data.Aeson             (FromJSON, parseJSON, Value)
@@ -32,12 +30,6 @@ dropEither :: Monad m => Either String a -> m a
 dropEither = \case 
      Left e  -> error e
      Right x -> return x
-
-
--- | TODO
-liftIOEither :: MonadIO m => IO (Either String a) -> m a
-liftIOEither =
-  dropEither <=< liftIO
 
 -- | Upgrades a handler that uses the `IO` monad with an `Either` inside into a
 -- base runtime handler.

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -14,9 +14,9 @@ module AWS.Lambda.Context (
   ClientContext(..),
   CognitoIdentity(..),
   LambdaContext(..),
+  getRemainingTime,
   HasLambdaContext(..),
   defConfig,
-  getRemainingTime,
   runReaderTLambdaContext
 ) where
 
@@ -77,6 +77,7 @@ data LambdaContext = LambdaContext
     identity           :: Maybe CognitoIdentity
   } deriving (Show, Generic)
 
+{-# DEPRECATED HasLambdaContext "HasLambdaContext will be removed along with the original mRuntimeWithContext.  This utility is no longer necessary without it." #-}
 class HasLambdaContext r where
   withContext :: (LambdaContext -> r -> r)
 
@@ -87,5 +88,6 @@ instance DefConfig LambdaContext where
   defConfig = LambdaContext "" "" 0 "" "" "" "" "" (posixSecondsToUTCTime 0) Nothing Nothing
 
 -- | Helper for using arbitrary monads with only the LambdaContext in its Reader
+{-# DEPRECATED runReaderTLambdaContext "runReaderTLambdaContext will be removed along with the original mRuntimeWithContext.  This particular approach was problematic, in that it required a default LambdaContext, when in reality, there is no valid instance." #-}
 runReaderTLambdaContext :: ReaderT LambdaContext m a -> m a
 runReaderTLambdaContext = flip runReaderT defConfig

--- a/src/AWS/Lambda/Runtime/Value.hs
+++ b/src/AWS/Lambda/Runtime/Value.hs
@@ -42,10 +42,10 @@ module AWS.Lambda.Runtime.Value (
 
 import           AWS.Lambda.RuntimeClient (RuntimeClientConfig, getRuntimeClientConfig,
                                            getNextData, sendEventError, sendEventSuccess)
-import           AWS.Lambda.Combinators   (liftIOEither, withoutContext)
+import           AWS.Lambda.Combinators   (withoutContext)
 import           AWS.Lambda.Context       (LambdaContext(..), HasLambdaContext(..))
 import           Control.Exception        (SomeException, displayException)
-import           Control.Monad            (forever)
+import           Control.Monad            ((<=<), forever)
 import           Control.Monad.Catch      (MonadCatch, try)
 import           Control.Monad.IO.Class   (MonadIO, liftIO)
 import           Control.Monad.Reader     (MonadReader, ReaderT, local, runReaderT)
@@ -217,7 +217,7 @@ readerTRuntime fn = mRuntimeWithContext' $ flip (runReaderT . fn)
 -- @
 ioRuntimeWithContext :: ToJSON result =>
   (LambdaContext -> Value -> IO (Either String result)) -> IO ()
-ioRuntimeWithContext = mRuntimeWithContext' . fmap (fmap liftIOEither)
+ioRuntimeWithContext fn = mRuntimeWithContext' (\lc -> either error pure <=< liftIO . fn lc)
 
 -- | For functions with IO that can fail in a pure way (or via throw).
 --


### PR DESCRIPTION
…he current mRuntimeWithContext.  Deprecate all functions that only exist to support the previous pattern.

Another notable effect of this is that now `LambdaContext` is only lazily available.  This theoretically saves some work, and also makes `sam local` work if the context is never inspected.

Based on this discussion https://github.com/Nike-Inc/hal/pull/77#discussion_r569201368 and inputs and insights from @endgame.