### PR TITLE
Drop http-conduit as a dependency

### DIFF
--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d43ec18e49bb7ce77fd444cdf150662cb6ff0f3c8ba1349dbd4318e6b5bc7e29
+-- hash: afb08ca777c8ba66061199260eb5bbbf73e3ccd8e245287fc9428d4a1e3a37b7
 
 name:           hal
 version:        0.4.6
@@ -58,7 +58,6 @@ library
     , envy <2
     , exceptions
     , http-client
-    , http-conduit
     , http-types
     , mtl
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -59,7 +59,6 @@ library:
     - conduit-extra
     - envy < 2
     - http-client
-    - http-conduit
     - http-types
     - exceptions
     - mtl

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -34,6 +34,7 @@ import qualified Data.ByteString.Lazy      as BSW
 import qualified Data.ByteString.Internal  as BSI
 import           Data.Conduit              (ConduitM, runConduit, yield, (.|))
 import           Data.Conduit.Attoparsec   (sinkParser)
+import           Data.Semigroup            ((<>))
 import           Data.Text.Encoding        (decodeUtf8)
 import           Data.Time.Clock.POSIX     (posixSecondsToUTCTime)
 import           GHC.Generics              (Generic (..))


### PR DESCRIPTION
…, as it was only providing simple helpers.

Notably, this drops `cryptonite` which is a bit more work to build in newer versions for lambda.  This doesn't save anyone who truly needs it (essentially users of HTTPS), but it at least simplifies builds for those who don't.