### PR TITLE
Feature/m runtime with context prime finish

### DIFF
--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -49,46 +49,51 @@ mRuntime = ValueRuntime.mRuntime . withInfallibleParse
 
 
 --TODO: Revisit all names before we put them under contract
--- | For any monad that supports IO/catch/Reader LambdaContext.
+-- | For any monad that supports IO\/catch\/Reader LambdaContext.
 --
--- Use this if you need caching behavours or are comfortable
--- manipulating monad transformers and want full control over
--- your monadic interface.
+-- This function is problematic, and has been deprecated. The
+-- 'HasLambdaContext' constraint requires that a 'LambdaContext' is
+-- settable in the @m@ monad, but that is not the case - we only have
+-- a 'LambdaContext' during the request/response cycle.
+--
+-- If you need caching behavours or are comfortable manipulating monad
+-- transformers and want full control over your monadic interface,
+-- consider 'mRuntimeWithContext''.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Context (LambdaContext(..), runReaderTLambdaContext)
---     import AWS.Lambda.Runtime (mRuntimeWithContext)
---     import Control.Monad.Reader (ReaderT, ask)
---     import Control.Monad.State.Lazy (StateT, evalStateT, get, put)
---     import Control.Monad.Trans (liftIO)
---     import Data.Aeson (FromJSON)
---     import Data.Text (unpack)
---     import System.Environment (getEnv)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Context (LambdaContext(..), runReaderTLambdaContext)
+-- import AWS.Lambda.Runtime (mRuntimeWithContext)
+-- import Control.Monad.Reader (ReaderT, ask)
+-- import Control.Monad.State.Lazy (StateT, evalStateT, get, put)
+-- import Control.Monad.Trans (liftIO)
+-- import Data.Aeson (FromJSON)
+-- import Data.Text (unpack)
+-- import System.Environment (getEnv)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: Named -> StateT Int (ReaderT LambdaContext IO) String
---     myHandler Named { name } = do
---       LambdaContext { functionName } <- ask
---       greeting <- liftIO $ getEnv \"GREETING\"
+-- myHandler :: Named -> StateT Int (ReaderT LambdaContext IO) String
+-- myHandler Named { name } = do
+--   LambdaContext { functionName } <- ask
+--   greeting <- liftIO $ getEnv \"GREETING\"
 --
---       greetingCount <- get
---       put $ greetingCount + 1
+--   greetingCount <- get
+--   put $ greetingCount + 1
 --
---       return $ greeting ++ name ++ " (" ++ show greetingCount ++ ") from " ++ unpack functionName ++ "!"
+--   return $ greeting ++ name ++ " (" ++ show greetingCount ++ ") from " ++ unpack functionName ++ "!"
 --
---     main :: IO ()
---     main = runReaderTLambdaContext (evalStateT (mRuntimeWithContext myHandler) 0)
+-- main :: IO ()
+-- main = runReaderTLambdaContext (evalStateT (mRuntimeWithContext myHandler) 0)
 -- @
-{-# DEPRECATED mRuntimeWithContext "mRuntimeWithContext will be replaced with mRuntimeWithContext' in future versions.  The original signature was problematic in that it pretended the LambdaContext was always available, when that is not the case." #-}
+{-# DEPRECATED mRuntimeWithContext "mRuntimeWithContext will be replaced by mRuntimeWithContext' in a future version. This type signature makes impossible promises - see the haddock for details." #-}
 mRuntimeWithContext :: (HasLambdaContext r, MonadCatch m, MonadReader r m, MonadIO m, FromJSON event, ToJSON result) =>
   (event -> m result) -> m ()
 mRuntimeWithContext = ValueRuntime.mRuntimeWithContext . withInfallibleParse
@@ -101,32 +106,32 @@ mRuntimeWithContext = ValueRuntime.mRuntimeWithContext . withInfallibleParse
 -- However, do not use this runtime if you need stateful (caching) behaviors.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Context (LambdaContext(..))
---     import AWS.Lambda.Runtime (readerTRuntime)
---     import Control.Monad.Reader (ReaderT, ask)
---     import Control.Monad.Trans (liftIO)
---     import Data.Aeson (FromJSON)
---     import Data.Text (unpack)
---     import System.Environment (getEnv)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Context (LambdaContext(..))
+-- import AWS.Lambda.Runtime (readerTRuntime)
+-- import Control.Monad.Reader (ReaderT, ask)
+-- import Control.Monad.Trans (liftIO)
+-- import Data.Aeson (FromJSON)
+-- import Data.Text (unpack)
+-- import System.Environment (getEnv)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: Named -> ReaderT LambdaContext IO String
---     myHandler Named { name } = do
---       LambdaContext { functionName } <- ask
---       greeting <- liftIO $ getEnv \"GREETING\"
---       return $ greeting ++ name ++ " from " ++ unpack functionName ++ "!"
+-- myHandler :: Named -> ReaderT LambdaContext IO String
+-- myHandler Named { name } = do
+--   LambdaContext { functionName } <- ask
+--   greeting <- liftIO $ getEnv \"GREETING\"
+--   return $ greeting ++ name ++ " from " ++ unpack functionName ++ "!"
 --
---     main :: IO ()
---     main = readerTRuntime myHandler
+-- main :: IO ()
+-- main = readerTRuntime myHandler
 -- @
 readerTRuntime :: (FromJSON event, ToJSON result) =>
   (event -> ReaderT LambdaContext IO result) -> IO ()
@@ -140,29 +145,29 @@ readerTRuntime = ValueRuntime.readerTRuntime . withInfallibleParse
 -- However, do not use this runtime if you need stateful (caching) behaviors.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Context (LambdaContext(..))
---     import AWS.Lambda.Runtime (ioRuntimeWithContext)
---     import Data.Aeson (FromJSON)
---     import Data.Text (unpack)
---     import System.Environment (getEnv)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Context (LambdaContext(..))
+-- import AWS.Lambda.Runtime (ioRuntimeWithContext)
+-- import Data.Aeson (FromJSON)
+-- import Data.Text (unpack)
+-- import System.Environment (getEnv)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: LambdaContext -> Named -> IO (Either String String)
---     myHandler (LambdaContext { functionName }) (Named { name }) = do
---       greeting <- getEnv \"GREETING\"
---       return $ pure $ greeting ++ name ++ " from " ++ unpack functionName ++ "!"
+-- myHandler :: LambdaContext -> Named -> IO (Either String String)
+-- myHandler (LambdaContext { functionName }) (Named { name }) = do
+--   greeting <- getEnv \"GREETING\"
+--   return $ pure $ greeting ++ name ++ " from " ++ unpack functionName ++ "!"
 --
---     main :: IO ()
---     main = ioRuntimeWithContext myHandler
+-- main :: IO ()
+-- main = ioRuntimeWithContext myHandler
 -- @
 ioRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> IO (Either String result)) -> IO ()
@@ -175,27 +180,27 @@ ioRuntimeWithContext = ValueRuntime.ioRuntimeWithContext . fmap withInfalliblePa
 -- However, do not use this runtime if you need stateful (caching) behaviors.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Runtime (ioRuntime)
---     import Data.Aeson (FromJSON)
---     import System.Environment (getEnv)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Runtime (ioRuntime)
+-- import Data.Aeson (FromJSON)
+-- import System.Environment (getEnv)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: Named -> IO (Either String String)
---     myHandler (Named { name }) = do
---       greeting <- getEnv \"GREETING\"
---       return $ pure $ greeting ++ name
+-- myHandler :: Named -> IO (Either String String)
+-- myHandler (Named { name }) = do
+--   greeting <- getEnv \"GREETING\"
+--   return $ pure $ greeting ++ name
 --
---     main :: IO ()
---     main = ioRuntime myHandler
+-- main :: IO ()
+-- main = ioRuntime myHandler
 -- @
 ioRuntime :: (FromJSON event, ToJSON result) =>
   (event -> IO (Either String result)) -> IO ()
@@ -207,30 +212,30 @@ ioRuntime = ValueRuntime.ioRuntime . withInfallibleParse
 -- but can fail and need the AWS Lambda Context as input.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Context (LambdaContext(..))
---     import AWS.Lambda.Runtime (fallibleRuntimeWithContext)
---     import Data.Aeson (FromJSON)
---     import Data.Text (unpack)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Context (LambdaContext(..))
+-- import AWS.Lambda.Runtime (fallibleRuntimeWithContext)
+-- import Data.Aeson (FromJSON)
+-- import Data.Text (unpack)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: LambdaContext -> Named -> Either String String
---     myHandler (LambdaContext { functionName }) (Named { name }) =
---       if name == \"World\" then
---         Right $ "Hello, World from " ++ unpack functionName ++ "!"
---       else
---         Left "Can only greet the world."
+-- myHandler :: LambdaContext -> Named -> Either String String
+-- myHandler (LambdaContext { functionName }) (Named { name }) =
+--   if name == \"World\" then
+--     Right $ "Hello, World from " ++ unpack functionName ++ "!"
+--   else
+--     Left "Can only greet the world."
 --
---     main :: IO ()
---     main = fallibleRuntimeWithContext myHandler
+-- main :: IO ()
+-- main = fallibleRuntimeWithContext myHandler
 -- @
 fallibleRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> Either String result) -> IO ()
@@ -242,28 +247,28 @@ fallibleRuntimeWithContext = ValueRuntime.fallibleRuntimeWithContext . fmap with
 -- but can fail.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Runtime (fallibleRuntime)
---     import Data.Aeson (FromJSON)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Runtime (fallibleRuntime)
+-- import Data.Aeson (FromJSON)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: Named -> Either String String
---     myHandler (Named { name }) =
---       if name == \"World\" then
---         Right "Hello, World!"
---       else
---         Left "Can only greet the world."
+-- myHandler :: Named -> Either String String
+-- myHandler (Named { name }) =
+--   if name == \"World\" then
+--     Right "Hello, World!"
+--   else
+--     Left "Can only greet the world."
 --
---     main :: IO ()
---     main = fallibleRuntime myHandler
+-- main :: IO ()
+-- main = fallibleRuntime myHandler
 -- @
 fallibleRuntime :: (FromJSON event, ToJSON result) =>
   (event -> Either String result) -> IO ()
@@ -275,27 +280,27 @@ fallibleRuntime = ValueRuntime.fallibleRuntime . withInfallibleParse
 -- but that need the AWS Lambda Context as input.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Context (LambdaContext(..))
---     import AWS.Lambda.Runtime (pureRuntimeWithContext)
---     import Data.Aeson (FromJSON)
---     import Data.Text (unpack)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Context (LambdaContext(..))
+-- import AWS.Lambda.Runtime (pureRuntimeWithContext)
+-- import Data.Aeson (FromJSON)
+-- import Data.Text (unpack)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: LambdaContext -> Named -> String
---     myHandler (LambdaContext { functionName }) (Named { name }) =
---       "Hello, " ++ name ++ " from " ++ unpack functionName ++ "!"
+-- myHandler :: LambdaContext -> Named -> String
+-- myHandler (LambdaContext { functionName }) (Named { name }) =
+--   "Hello, " ++ name ++ " from " ++ unpack functionName ++ "!"
 --
---     main :: IO ()
---     main = pureRuntimeWithContext myHandler
+-- main :: IO ()
+-- main = pureRuntimeWithContext myHandler
 -- @
 pureRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> result) -> IO ()
@@ -306,24 +311,24 @@ pureRuntimeWithContext = ValueRuntime.pureRuntimeWithContext . fmap withInfallib
 -- Use this for simple handlers that just translate input to output without side-effects.
 --
 -- @
---     {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
+-- {-\# LANGUAGE NamedFieldPuns, DeriveGeneric \#-}
 --
---     module Main where
+-- module Main where
 --
---     import AWS.Lambda.Runtime (pureRuntime)
---     import Data.Aeson (FromJSON)
---     import GHC.Generics (Generic)
+-- import AWS.Lambda.Runtime (pureRuntime)
+-- import Data.Aeson (FromJSON)
+-- import GHC.Generics (Generic)
 --
---     data Named = Named {
---       name :: String
---     } deriving Generic
---     instance FromJSON Named
+-- data Named = Named {
+--   name :: String
+-- } deriving Generic
+-- instance FromJSON Named
 --
---     myHandler :: Named -> String
---     myHandler Named { name } = "Hello, " ++ name ++ "!"
+-- myHandler :: Named -> String
+-- myHandler Named { name } = "Hello, " ++ name ++ "!"
 --
---     main :: IO ()
---     main = pureRuntime myHandler
+-- main :: IO ()
+-- main = pureRuntime myHandler
 -- @
 pureRuntime :: (FromJSON event, ToJSON result) => (event -> result) -> IO ()
 pureRuntime = ValueRuntime.pureRuntime . withInfallibleParse

--- a/src/AWS/Lambda/Runtime/Value.hs
+++ b/src/AWS/Lambda/Runtime/Value.hs
@@ -68,7 +68,7 @@ runtimeLoop runtimeClientConfig fn = do
   -}
   -- Put any exceptions in an Either
   caughtResult <- try (fn (either error id eCtx) event)
-  -- Map the Either (via first) so it is an `Either String a`
+  -- Map the Either (via first) so it is an `Either String result`
   let result = first (displayException :: SomeException -> String) caughtResult
 
   liftIO $ case result of


### PR DESCRIPTION
Fill out TODO haddocks, explain (in haddock) why `mRuntimeWithContext` is deprecated, and correct a couple of bits and pieces.

Merges onto #82 .