### PR TITLE
Support optional response bodies in API Gateway Proxy Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
+## `0.5.0` - Unreleased
+
+  - `AWS.Lambda.Events.ApiGateway.ProxyResponse` now contains a `Maybe
+    ProxyBody`
+  - New function: `AWS.Lambda.Events.ApiGateway.ProxyResponse.responseNoBody`,
+
 ## `0.4.7` - 2021-04-12
 
   - Drop http-conduit as a dependency for potentially smaller binaries

--- a/src/AWS/Lambda/Events/ApiGateway/ProxyRequest.hs
+++ b/src/AWS/Lambda/Events/ApiGateway/ProxyRequest.hs
@@ -114,15 +114,13 @@ instance FromJSON a => FromJSON (RequestContext a) where
 --     myHandler ProxyRequest { httpMethod = \"GET\", path = "/say_hello" } =
 --         ProxyResponse
 --         {   status = ok200
---         ,   body = textPlain \"Hello\"
---         ,   headers = mempty
+--         ,   body = Just $ textPlain \"Hello\"
 --         ,   multiValueHeaders = mempty
 --         }
 --     myHandler _ =
 --         ProxyResponse
 --         {   status = forbidden403
---         ,   body = textPlain \"Forbidden\"
---         ,   headers = mempty
+--         ,   body = Just $ textPlain \"Forbidden\"
 --         ,   multiValueHeaders = mempty
 --         }
 --


### PR DESCRIPTION
It's useful to be able to generate 3xx redirections from an API Gateway Lambda Proxy Integration. These don't need to return a body.

You can test that this is fine by integrating a JS lambda like the one below with API Gateway:
<details>
<summary><code>index.js</code></summary>
<pre lang="js">
exports.handler = async (event) => {
    const response = {
        statusCode: 302,
        headers: {
            "Location": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
        }
    };
    return response;
};
</pre>
</details>

I've tried to keep the changes as small as possible, but this does force a breaking change to the API (if you weren't using smart constructors to generate response bodies). `responseNoBody` is a new smart constructor to avoid changing the type of `response`. Since it's a rarer occasion, a longer name feels fine.

Unless there's massive urgency for a new release, I think this should be batched up with #90, once I deploy some test lambdas.

Do we want to remove all the deprecated runtime functions when we bump the version number? I'm happy to do this in another PR.