### PR TITLE
Use CPP macros to eliminate warnings…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
   - When the runtime encounters an error, write it out to the Cloudwatch logs
     (via stderr), and do so in a format that can be guaranteed and later
     extended.
+  - Eliminate redundant import compiler warnings
 
 ## `0.4.9` - 2022-02-28
 

--- a/src/AWS/Lambda/Events/ApiGateway/ProxyResponse.hs
+++ b/src/AWS/Lambda/Events/ApiGateway/ProxyResponse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-|
 Module      : AWS.Lambda.Events.ApiGateway.ProxyResponse
 Description : Data types that represent typical lambda responses
@@ -35,7 +36,9 @@ import           Data.Foldable             (fold)
 import           Data.Hashable             (Hashable)
 import           Data.HashMap.Strict       (HashMap)
 import qualified Data.HashMap.Strict       as H
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup            ((<>))
+#endif
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as TE
 import qualified Data.Text.Lazy            as TL

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -53,7 +53,9 @@ import           Data.Int               (Int32, Int64)
 import           Data.Map               (Map)
 import           Data.Maybe             (catMaybes, maybeToList)
 import           Data.Scientific        (toBoundedInteger)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup         ((<>))
+#endif
 import           Data.Text              (Text)
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as TE

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-|
 Module      : AWS.Lambda.RuntimeClient
 Description : HTTP related machinery for talking to the AWS Lambda Custom Runtime interface.
@@ -19,7 +20,6 @@ module AWS.Lambda.RuntimeClient (
 import           AWS.Lambda.Context                (LambdaContext)
 import           AWS.Lambda.Internal               (StaticContext, getStaticContext)
 import           AWS.Lambda.RuntimeClient.Internal (eventResponseToNextData)
-import           Control.Applicative               ((<*>))
 import           Control.Concurrent                (threadDelay)
 import           Control.Exception                 (IOException, displayException,
                                                     throw, try)
@@ -34,7 +34,9 @@ import qualified Data.ByteString.Lazy              as BSW
 import           Data.Conduit                      (ConduitM, runConduit, yield,
                                                     (.|))
 import           Data.Conduit.Attoparsec           (sinkParser)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup                    ((<>))
+#endif
 import           GHC.Generics                      (Generic (..))
 import           Network.HTTP.Client               (BodyReader, HttpException,
                                                     Manager, Request,

--- a/src/AWS/Lambda/RuntimeClient/Internal.hs
+++ b/src/AWS/Lambda/RuntimeClient/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-|
 Module      : AWS.Lambda.RuntimeClient.Internal
 Description : Internal HTTP related machinery for talking to the AWS Lambda Custom Runtime interface.
@@ -22,7 +23,9 @@ import qualified Data.ByteString.Char8    as BSC
 import qualified Data.ByteString.Internal as BSI
 import qualified Data.ByteString.Lazy     as BSW
 import           Data.CaseInsensitive     (original)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup           ((<>))
+#endif
 import           Data.Text.Encoding       (decodeUtf8)
 import           Data.Time.Clock.POSIX    (posixSecondsToUTCTime)
 import           Network.HTTP.Client      (Response, responseBody,

--- a/test/AWS/Lambda/Events/ApiGateway/ProxyRequest/Gen/Parameters.hs
+++ b/test/AWS/Lambda/Events/ApiGateway/ProxyRequest/Gen/Parameters.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE CPP #-}
 module AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen.Parameters where
 
 import           Control.Monad.Trans.State
 import           Data.HashMap.Strict       (HashMap)
 import qualified Data.HashMap.Strict       as H
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup            ((<>))
+#endif
 import           Data.Set                  (Set)
 import qualified Data.Set                  as S
 import           Data.Text                 (Text)

--- a/test/AWS/Lambda/Events/ApiGateway/ProxyRequest/Gen/Resource.hs
+++ b/test/AWS/Lambda/Events/ApiGateway/ProxyRequest/Gen/Resource.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE CPP #-}
 
 module AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen.Resource where
 
@@ -9,7 +10,9 @@ import           Data.HashMap.Strict       (HashMap)
 import qualified Data.HashMap.Strict       as H
 import           Data.List.NonEmpty        (NonEmpty)
 import qualified Data.List.NonEmpty        as NE
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup            ((<>))
+#endif
 import qualified Data.Set                  as S
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T

--- a/test/AWS/Lambda/Events/Kafka/Gen.hs
+++ b/test/AWS/Lambda/Events/Kafka/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module AWS.Lambda.Events.Kafka.Gen where
 
 import AWS.Lambda.Events.Kafka              (KafkaEvent(KafkaEvent),
@@ -14,7 +15,9 @@ import           Data.List                  (intersperse)
 import qualified Data.List.NonEmpty         as NE
 import           Data.List.NonEmpty         (NonEmpty)
 import           Data.Map                   (Map)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup             ((<>))
+#endif
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Time                  (UTCTime)

--- a/test/Gen/Header.hs
+++ b/test/Gen/Header.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Gen.Header where
 
 import           Control.Monad.Trans.State
@@ -6,7 +7,9 @@ import qualified Data.CaseInsensitive      as CI
 import           Data.Char                 (toUpper, toLower)
 import           Data.HashMap.Strict       (HashMap)
 import qualified Data.HashMap.Strict       as H
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup            ((<>))
+#endif
 import           Data.Set                  (Set)
 import qualified Data.Set                  as S
 import           Data.Text                 (Text)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 import           AWS.Lambda.Context                 (ClientApplication (..),
                                                      ClientContext (..),
                                                      CognitoIdentity (..),
@@ -13,7 +14,9 @@ import           AWS.Lambda.RuntimeClient.Internal  (eventResponseToNextData)
 import           Data.Aeson                         (Value (Null))
 import qualified Data.CaseInsensitive               as CI
 import           Data.Map                           (singleton)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup                     ((<>))
+#endif
 import           Data.Time.Clock.POSIX              (posixSecondsToUTCTime)
 import           Hedgehog
 import qualified Hedgehog.Gen                       as Gen


### PR DESCRIPTION
…with more recent base versions while still supporting older ones.