### PR TITLE
Kafka event mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
+## Unreleased
+
+  - Add `KafkaEvent` type for subscribing Lambda functions to Kafka
+    topics
+  - Support `aeson ^>=2.0.0.0`
+
 ## `0.4.8` - 2021-05-07
 
   - Add `ToJSON` instances for `ProxyRequest` types, and test

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 379155184c5b0737922c4723661569ad7f8dded92f329cf103cce715f86505d9
+-- hash: 7a06a90a677a7608851d79aabd34f2ce8856ba75c861cc7c8a0c54e8e6e11a82
 
 name:           hal
 version:        0.4.8
@@ -96,7 +96,9 @@ test-suite hal-test
       AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen
       AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen.Parameters
       AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen.Resource
+      AWS.Lambda.Events.ApiGateway.ProxyRequest.Spec
       AWS.Lambda.Events.ApiGateway.ProxyResponse.Gen
+      AWS.Lambda.Events.ApiGateway.ProxyResponse.Spec
       AWS.Lambda.Events.Kafka.Gen
       AWS.Lambda.Events.Kafka.Spec
       Gen.Header

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ceac41e0b7ecf9703f0386c1dcbb54be76a095278f561d301f7e5cf1fabece71
+-- hash: e409c6f94d9233f3717ac3daa95fbd3d9e657ac64b956c2ba9ca28ad6bec4791
 
 name:           hal
 version:        0.4.8
@@ -126,7 +126,7 @@ test-suite hal-test
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.5.0.0 && <1.6 || >=2.0.0.0 && <2.1
+      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.1
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring

--- a/hal.cabal
+++ b/hal.cabal
@@ -86,7 +86,6 @@ library
     , text
     , time
     , unordered-containers
-    , vector >=0.12.0.0 && <0.13
   default-language: Haskell2010
 
 test-suite hal-test
@@ -144,5 +143,5 @@ test-suite hal-test
     , time
     , transformers
     , unordered-containers
-    , vector
+    , vector >=0.12.0.0 && <0.13
   default-language: Haskell2010

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7a06a90a677a7608851d79aabd34f2ce8856ba75c861cc7c8a0c54e8e6e11a82
+-- hash: 327a2d82769ec84b924f14400948e4bd8307be4791cbd7810a48856ce7827053
 
 name:           hal
 version:        0.4.8
@@ -82,11 +82,11 @@ library
     , http-client
     , http-types
     , mtl
-    , scientific >=0.3.7.0 && <0.4
+    , scientific >=0.3.3.0 && <0.4
     , text
     , time
     , unordered-containers
-    , vector >=0.12.3.1 && <0.13
+    , vector >=0.12.0.0 && <0.13
   default-language: Haskell2010
 
 test-suite hal-test

--- a/hal.cabal
+++ b/hal.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7c955e07ae70fb5926acbb0029b59e32fb611f8acf5fbac34f5112f883602f07
+-- hash: 379155184c5b0737922c4723661569ad7f8dded92f329cf103cce715f86505d9
 
 name:           hal
 version:        0.4.8
@@ -35,6 +35,7 @@ library
       AWS.Lambda.Context
       AWS.Lambda.Events.ApiGateway.ProxyRequest
       AWS.Lambda.Events.ApiGateway.ProxyResponse
+      AWS.Lambda.Events.Kafka
       AWS.Lambda.Events.S3
       AWS.Lambda.Events.SQS
       AWS.Lambda.Internal
@@ -46,7 +47,25 @@ library
       Paths_hal
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings BangPatterns DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DuplicateRecordFields EmptyCase GeneralizedNewtypeDeriving InstanceSigs LambdaCase MultiParamTypeClasses MultiWayIf OverloadedStrings PatternSynonyms ScopedTypeVariables
+  default-extensions:
+      OverloadedStrings
+      BangPatterns
+      DefaultSignatures
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DuplicateRecordFields
+      EmptyCase
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      OverloadedStrings
+      PatternSynonyms
+      ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
       aeson
@@ -63,9 +82,11 @@ library
     , http-client
     , http-types
     , mtl
+    , scientific >=0.3.7.0 && <0.4
     , text
     , time
     , unordered-containers
+    , vector >=0.12.3.1 && <0.13
   default-language: Haskell2010
 
 test-suite hal-test
@@ -76,11 +97,31 @@ test-suite hal-test
       AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen.Parameters
       AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen.Resource
       AWS.Lambda.Events.ApiGateway.ProxyResponse.Gen
+      AWS.Lambda.Events.Kafka.Gen
+      AWS.Lambda.Events.Kafka.Spec
       Gen.Header
       Paths_hal
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings BangPatterns DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DuplicateRecordFields EmptyCase GeneralizedNewtypeDeriving InstanceSigs LambdaCase MultiParamTypeClasses MultiWayIf OverloadedStrings PatternSynonyms ScopedTypeVariables
+  default-extensions:
+      OverloadedStrings
+      BangPatterns
+      DefaultSignatures
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DuplicateRecordFields
+      EmptyCase
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      OverloadedStrings
+      PatternSynonyms
+      ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
@@ -95,6 +136,7 @@ test-suite hal-test
     , hspec-hedgehog
     , http-client
     , http-types >=0.12.2 && <0.13
+    , raw-strings-qq ==1.1.*
     , scientific
     , text
     , time

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 327a2d82769ec84b924f14400948e4bd8307be4791cbd7810a48856ce7827053
+-- hash: ceac41e0b7ecf9703f0386c1dcbb54be76a095278f561d301f7e5cf1fabece71
 
 name:           hal
 version:        0.4.8
@@ -126,7 +126,7 @@ test-suite hal-test
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson
+      aeson >=1.5.0.0 && <1.6 || >=2.0.0.0 && <2.1
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -83,7 +83,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hal
-    - aeson ^>=1.5.0.0 || ^>=2.0.0.0
+    - aeson >=1.2.0.0 && <1.6 || ^>=2.0.0.0
     - base64-bytestring
     - bytestring
     - case-insensitive

--- a/package.yaml
+++ b/package.yaml
@@ -67,10 +67,10 @@ library:
     - http-client
     - http-types
     - mtl
-    - scientific ^>=0.3.7.0
+    - scientific ^>=0.3.3.0
     - text
     - time
-    - vector ^>=0.12.3.1
+    - vector ^>=0.12.0.0
     - unordered-containers
 
 tests:

--- a/package.yaml
+++ b/package.yaml
@@ -83,7 +83,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hal
-    - aeson
+    - aeson ^>=1.5.0.0 || ^>=2.0.0.0
     - base64-bytestring
     - bytestring
     - case-insensitive

--- a/package.yaml
+++ b/package.yaml
@@ -55,21 +55,23 @@ library:
   source-dirs: src
   dependencies:
     - aeson
+    - base64-bytestring
     - bytestring
+    - case-insensitive
     - conduit
     - conduit-extra
+    - containers
     - envy
+    - exceptions
     - hashable
     - http-client
     - http-types
-    - exceptions
     - mtl
-    - containers
-    - unordered-containers
-    - time
+    - scientific ^>=0.3.7.0
     - text
-    - base64-bytestring
-    - case-insensitive
+    - time
+    - vector ^>=0.12.3.1
+    - unordered-containers
 
 tests:
   hal-test:
@@ -91,6 +93,7 @@ tests:
     - hspec-hedgehog
     - http-client
     - http-types ^>= 0.12.2
+    - raw-strings-qq ^>=1.1
     - scientific
     - text
     - time

--- a/package.yaml
+++ b/package.yaml
@@ -70,7 +70,6 @@ library:
     - scientific ^>=0.3.3.0
     - text
     - time
-    - vector ^>=0.12.0.0
     - unordered-containers
 
 tests:
@@ -99,4 +98,4 @@ tests:
     - time
     - transformers
     - unordered-containers
-    - vector
+    - vector ^>=0.12.0.0

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -53,6 +53,7 @@ import           Data.Int               (Int32, Int64)
 import           Data.Map               (Map)
 import           Data.Maybe             (catMaybes, maybeToList)
 import           Data.Scientific        (toBoundedInteger)
+import           Data.Semigroup         ((<>))
 import           Data.Text              (Text)
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as TE

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -142,7 +142,7 @@ type Record = Record' ByteString
 -- you can do things like parse a JSON-encoded payload:
 --
 -- @
--- 'traverse' 'decodeStrict' :: 'FromJSON' a => Record ByteString -> Maybe (Record a)
+-- 'traverse' 'decodeStrict' :: 'FromJSON' a => Record -> Maybe (Record' a)
 -- @
 data Record' a = Record {
   topic :: !Text,

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -59,7 +59,6 @@ import qualified Data.Text.Encoding     as TE
 import           Data.Time              (UTCTime)
 import           Data.Time.Clock.POSIX  (posixSecondsToUTCTime,
                                          utcTimeToPOSIXSeconds)
-import           Data.Vector            (Vector)
 import           GHC.Generics           (Generic)
 
 #if MIN_VERSION_aeson(2,0,0)
@@ -150,7 +149,7 @@ data Record' a = Record {
   offset :: !Int64,
   timestamp :: !Timestamp,
   -- | NOTE: there can be multiple headers for a given key.
-  headers :: !(Vector Header),
+  headers :: [Header],
   key :: !(Maybe ByteString),
   value :: !(Maybe a)
 } deriving (Eq, Show, Generic, Functor, Foldable, Traversable)

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 
 {-|
@@ -157,7 +156,7 @@ data Record' a = Record {
 } deriving (Eq, Show, Generic, Functor, Foldable, Traversable)
 
 -- | Decodes base64-encoded keys and values, where present.
-instance a ~ ByteString => FromJSON (Record' a) where
+instance FromJSON (Record' ByteString) where
   parseJSON = withObject "Record" $ \o -> do
     topic <- o .: "topic"
     partition <- o .: "partition"
@@ -169,7 +168,7 @@ instance a ~ ByteString => FromJSON (Record' a) where
     pure Record { topic, partition, offset, timestamp, headers, key, value }
 
 -- | Encodes keys and values into base64.
-instance a ~ ByteString => ToJSON (Record' a) where
+instance ToJSON (Record' ByteString) where
   toJSON r = object $ concat
     [
       [ "offset" .= offset r

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs             #-}
@@ -48,7 +49,6 @@ import qualified Data.ByteString.Base64 as B64
 import           Data.List.NonEmpty     (NonEmpty)
 import qualified Data.List.NonEmpty     as NE
 import           Data.Function          ((&))
-import qualified Data.HashMap.Strict    as H
 import           Data.Int               (Int32, Int64)
 import           Data.Map               (Map)
 import           Data.Maybe             (catMaybes, maybeToList)
@@ -61,6 +61,26 @@ import           Data.Time.Clock.POSIX  (posixSecondsToUTCTime,
                                          utcTimeToPOSIXSeconds)
 import           Data.Vector            (Vector)
 import           GHC.Generics           (Generic)
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key         as Key
+import qualified Data.Aeson.KeyMap      as KM
+
+keyToText :: Key -> Text
+keyToText = Key.toText
+
+keyFromText :: Text -> Key
+keyFromText = Key.fromText
+#else
+import qualified Data.HashMap.Strict    as KM
+type Key = Text
+
+keyToText :: Key -> Text
+keyToText = id
+
+keyFromText :: Text -> Key
+keyFromText = id
+#endif
 
 -- | Represents an event from either Amazon MSK or a self-managed
 -- Apache Kafka cluster, as the payloads are very similar.
@@ -178,13 +198,13 @@ data Header = Header !Text !ByteString deriving (Eq, Show, Generic)
 
 instance FromJSON Header where
   parseJSON = withObject "header" $ \o ->
-    case H.toList o of
-      [(key, value)] -> Header key . B.pack <$> parseJSON value
+    case KM.toList o of
+      [(key, value)] -> Header (keyToText key) . B.pack <$> parseJSON value
       [] -> fail "Unexpected empty object"
       _ -> fail "Unexpected additional keys in object"
 
 instance ToJSON Header where
-  toJSON (Header key value) = object [key .= B.unpack value]
+  toJSON (Header key value) = object [keyFromText key .= B.unpack value]
 
 -- | Kafka timestamp types, derived from the Java client's enum at:
 -- https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/TimestampType.java

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+
+{-|
+Module      : AWS.Lambda.Events.Kafka
+Description : Data types for consuming Kafka events.
+License     : BSD3
+Stability   : stable
+
+It is possible to subscribe Lambda functions to Kafka topics. You can
+subscribe to topics in Amazon Managed Streaming for Kafka (MSK) as
+well as self-managed Kafka clusters.
+
+The AWS documentation does not appear to detail the payload format for
+Kafka event sources. Lambda considers Amazon Managed Streaming for
+Kafka (MSK) to be a different event source type from a self-managed
+Apache Kafka cluster, but their payloads are very similar. The types
+in this module are derived from inspecting invocation payloads, and
+from reading the following blog posts:
+
+  * https://aws.amazon.com/blogs/compute/using-amazon-msk-as-an-event-source-for-aws-lambda/
+  * https://aws.amazon.com/blogs/compute/using-self-hosted-apache-kafka-as-an-event-source-for-aws-lambda/
+
+-}
+
+module AWS.Lambda.Events.Kafka (
+  KafkaEvent(..),
+  EventSource(..),
+  Record,
+  Record'(..),
+  Header (..),
+  Timestamp(..),
+  -- * Internal
+  parseTimestamp,
+  unparseTimestamp,
+  int64ToUTCTime,
+  utcTimeToInt64
+) where
+
+import           Data.Aeson
+import           Data.Aeson.Types
+import           Data.ByteString        (ByteString)
+import qualified Data.ByteString        as B
+import qualified Data.ByteString.Base64 as B64
+import           Data.List.NonEmpty     (NonEmpty)
+import qualified Data.List.NonEmpty     as NE
+import           Data.Function          ((&))
+import qualified Data.HashMap.Strict    as H
+import           Data.Int               (Int32, Int64)
+import           Data.Map               (Map)
+import           Data.Maybe             (catMaybes, maybeToList)
+import           Data.Scientific        (toBoundedInteger)
+import           Data.Text              (Text)
+import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as TE
+import           Data.Time              (UTCTime)
+import           Data.Time.Clock.POSIX  (posixSecondsToUTCTime,
+                                         utcTimeToPOSIXSeconds)
+import           Data.Vector            (Vector)
+import           GHC.Generics           (Generic)
+
+-- | Represents an event from either Amazon MSK or a self-managed
+-- Apache Kafka cluster, as the payloads are very similar.
+--
+-- The 'ToJSON' and 'FromJSON' instances on 'Record' perform base64
+-- conversion for you.
+--
+-- See the <https://docs.aws.amazon.com/lambda/latest/dg/with-kafka.html AWS documentation>
+-- for a sample payload.
+data KafkaEvent = KafkaEvent {
+  eventSource      :: !EventSource,
+  -- | Only present when using the "Amazon MSK" event source mapping.
+  eventSourceArn   :: !(Maybe Text),
+  bootstrapServers :: !(NonEmpty Text),
+  -- | The map's keys look like @"${topicName}-${partitionNumber}"@
+  records          :: !(Map Text [Record])
+} deriving (Eq, Show, Generic)
+
+instance FromJSON KafkaEvent where
+  parseJSON = withObject "KafkaEvent" $ \o ->
+    let parseBootstrapServers
+          = maybe (fail "bootstrapServers: empty string") pure
+          . NE.nonEmpty
+          . T.splitOn ","
+    in KafkaEvent
+         <$> o .: "eventSource"
+         <*> o .:! "eventSourceArn"
+         <*> (o .: "bootstrapServers" >>= parseBootstrapServers)
+         <*> o .: "records"
+
+instance ToJSON KafkaEvent where
+  toJSON e = object $
+    [ "eventSource" .= eventSource e
+    , "bootstrapServers" .= T.intercalate "," (NE.toList (bootstrapServers e))
+    , "records" .= records e
+    ] <> maybeToList (("eventSourceArn" .=) <$> eventSourceArn e)
+
+data EventSource
+  = AwsKafka -- ^ @"aws:kafka"@
+  | SelfManagedKafka -- ^ @"SelfManagedKafka"@
+  deriving (Eq, Show, Bounded, Enum, Ord, Generic)
+
+instance FromJSON EventSource where
+  parseJSON = withText "EventSource" $ \case
+    "aws:kafka" -> pure AwsKafka
+    "SelfManagedKafka" -> pure SelfManagedKafka
+    t -> fail $ "unrecognised EventSource: \"" <> show t <> "\""
+
+instance ToJSON EventSource where
+  toJSON = \case
+    AwsKafka -> String "aws:kafka"
+    SelfManagedKafka -> String "SelfManagedKafka"
+
+-- | Convenience alias: most of the time you will parse the records
+-- straight into some app-specific structure.
+type Record = Record' ByteString
+
+-- | Records from a Kafka event. This is 'Traversable', which means
+-- you can do things like parse a JSON-encoded payload:
+--
+-- @
+-- 'traverse' 'decodeStrict' :: 'FromJSON' a => Record ByteString -> Maybe (Record a)
+-- @
+data Record' a = Record {
+  topic :: !Text,
+  partition :: !Int32,
+  offset :: !Int64,
+  timestamp :: !Timestamp,
+  -- | NOTE: there can be multiple headers for a given key.
+  headers :: !(Vector Header),
+  key :: !(Maybe ByteString),
+  value :: !(Maybe a)
+} deriving (Eq, Show, Generic, Functor, Foldable, Traversable)
+
+-- | Decodes base64-encoded keys and values, where present.
+instance a ~ ByteString => FromJSON (Record' a) where
+  parseJSON = withObject "Record" $ \o -> do
+    topic <- o .: "topic"
+    partition <- o .: "partition"
+    offset <- o .: "offset"
+    timestamp <- parseTimestamp o
+    headers <- o .: "headers"
+    key <- fmap (B64.decodeLenient . TE.encodeUtf8) <$> o .:? "key"
+    value <- fmap (B64.decodeLenient . TE.encodeUtf8) <$> o .:? "value"
+    pure Record { topic, partition, offset, timestamp, headers, key, value }
+
+-- | Encodes keys and values into base64.
+instance a ~ ByteString => ToJSON (Record' a) where
+  toJSON r = object $ concat
+    [
+      [ "offset" .= offset r
+      , "partition" .= partition r
+      , "topic" .= topic r
+      , "headers" .= headers r
+      ]
+    , unparseTimestamp (timestamp r)
+    , catMaybes
+      [ ("key" .=) . TE.decodeUtf8 . B64.encode <$> key r
+      , ("value" .=) . TE.decodeUtf8 . B64.encode <$> value r
+      ]
+    ]
+
+-- | AWS serialises record headers to JSON as an array of
+-- objects. From their docs:
+--
+-- @
+-- "headers":[{"headerKey":[104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]}]
+-- @
+--
+-- Note:
+--
+-- >>> map chr [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]
+-- "headerValue"
+data Header = Header !Text !ByteString deriving (Eq, Show, Generic)
+
+instance FromJSON Header where
+  parseJSON = withObject "header" $ \o ->
+    case H.toList o of
+      [(key, value)] -> Header key . B.pack <$> parseJSON value
+      [] -> fail "Unexpected empty object"
+      _ -> fail "Unexpected additional keys in object"
+
+instance ToJSON Header where
+  toJSON (Header key value) = object [key .= B.unpack value]
+
+-- | Kafka timestamp types, derived from the Java client's enum at:
+-- https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/TimestampType.java
+data Timestamp = NoTimestampType | CreateTime !UTCTime | LogAppendTime !UTCTime
+  deriving (Eq, Show, Generic)
+
+parseTimestamp :: Object -> Parser Timestamp
+parseTimestamp o = explicitParseField parseSubtype o "timestampType"
+  where
+    parseSubtype = withText "timestampType" $ \case
+      "NO_TIMESTAMP_TYPE" -> pure NoTimestampType
+      "CREATE_TIME" -> CreateTime <$> parseUTCTimestamp
+      "LOG_APPEND_TIME" -> LogAppendTime <$> parseUTCTimestamp
+      t -> fail $ "unknown timestampType: \"" <> show t <> "\""
+
+    parseUTCTimestamp = explicitParseField convertToUTCTime o "timestamp"
+
+    convertToUTCTime = withScientific "timestamp" $ \stamp ->
+      int64ToUTCTime <$> (toBoundedInteger stamp &
+        maybe (fail "timestamp out of range") pure :: Parser Int64)
+
+unparseTimestamp :: KeyValue kv => Timestamp -> [kv]
+unparseTimestamp = \case
+  NoTimestampType -> ["timestampType" .= String "NO_TIMESTAMP_TYPE"]
+  CreateTime ts ->
+    [ "timestampType" .= String "CREATE_TIME"
+    , "timestamp" .= utcTimeToInt64 ts
+    ]
+  LogAppendTime ts ->
+    [ "timestampType" .= String "LOG_APPEND_TIME"
+    , "timestamp" .= utcTimeToInt64 ts
+    ]
+
+int64ToUTCTime :: Int64 -> UTCTime
+int64ToUTCTime int =
+  let (seconds, millis) = int `divMod` 1000
+      posixSeconds = fromIntegral seconds + fromIntegral millis / 1000
+  in posixSecondsToUTCTime posixSeconds
+
+utcTimeToInt64 :: UTCTime -> Int64
+utcTimeToInt64 utc = truncate $ utcTimeToPOSIXSeconds utc * 1000

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -10,16 +10,17 @@ License     : BSD3
 Stability   : stable
 
 It is possible to subscribe Lambda functions to Kafka topics. You can
-subscribe to topics in Amazon Managed Streaming for Kafka (MSK) as
+subscribe to topics from Amazon Managed Streaming for Kafka (MSK) as
 well as self-managed Kafka clusters.
 
-The AWS documentation does not appear to detail the payload format for
-Kafka event sources. Lambda considers Amazon Managed Streaming for
-Kafka (MSK) to be a different event source type from a self-managed
-Apache Kafka cluster, but their payloads are very similar. The types
-in this module are derived from inspecting invocation payloads, and
-from reading the following blog posts:
+Lambda considers Amazon Managed Streaming for Kafka (MSK) to be a
+different event source type from a self-managed Apache Kafka cluster,
+but their payloads are very similar. The types in this module are
+derived from inspecting invocation payloads, and from reading the
+following links:
 
+  * https://docs.aws.amazon.com/lambda/latest/dg/with-kafka.html
+  * https://docs.aws.amazon.com/lambda/latest/dg/with-msk.html
   * https://aws.amazon.com/blogs/compute/using-amazon-msk-as-an-event-source-for-aws-lambda/
   * https://aws.amazon.com/blogs/compute/using-self-hosted-apache-kafka-as-an-event-source-for-aws-lambda/
 

--- a/test/AWS/Lambda/Events/ApiGateway/ProxyRequest/Spec.hs
+++ b/test/AWS/Lambda/Events/ApiGateway/ProxyRequest/Spec.hs
@@ -1,0 +1,15 @@
+module AWS.Lambda.Events.ApiGateway.ProxyRequest.Spec where
+
+import qualified AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen as Gen
+import           Data.Aeson (decode, encode)
+import           Hedgehog
+import           Test.Hspec (Spec, describe, specify)
+import           Test.Hspec.Hedgehog (hedgehog)
+
+spec :: Spec
+spec = do
+    describe "properties" $
+        specify "tripping" $
+            hedgehog $ do
+                request <- forAll Gen.proxyRequest
+                tripping request encode decode

--- a/test/AWS/Lambda/Events/ApiGateway/ProxyResponse/Spec.hs
+++ b/test/AWS/Lambda/Events/ApiGateway/ProxyResponse/Spec.hs
@@ -1,0 +1,15 @@
+module AWS.Lambda.Events.ApiGateway.ProxyResponse.Spec where
+
+import qualified AWS.Lambda.Events.ApiGateway.ProxyResponse.Gen as Gen
+import           Data.Aeson (decode, encode)
+import           Hedgehog
+import           Test.Hspec (Spec, describe, specify)
+import           Test.Hspec.Hedgehog (hedgehog)
+
+spec :: Spec
+spec = do
+    describe "properties" $
+        specify "tripping" $
+            hedgehog $ do
+                request <- forAll Gen.proxyResponse
+                tripping request encode decode

--- a/test/AWS/Lambda/Events/Kafka/Gen.hs
+++ b/test/AWS/Lambda/Events/Kafka/Gen.hs
@@ -1,0 +1,109 @@
+module AWS.Lambda.Events.Kafka.Gen where
+
+import AWS.Lambda.Events.Kafka              (KafkaEvent(KafkaEvent),
+                                             EventSource (..),
+                                             Header(..),
+                                             Record,
+                                             Record'     (Record),
+                                             Timestamp   (..),
+                                             int64ToUTCTime)
+import           Control.Applicative        (liftA2)
+import           Data.Char                  (isPrint)
+import           Data.Foldable              (fold)
+import           Data.List                  (intersperse)
+import qualified Data.List.NonEmpty         as NE
+import           Data.List.NonEmpty         (NonEmpty)
+import           Data.Map                   (Map)
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+import           Data.Time                  (UTCTime)
+import           Data.Traversable           (for)
+import           Data.Vector
+import qualified Data.Vector                as V
+import           Hedgehog                   (Gen)
+import qualified Hedgehog.Gen               as Gen
+import qualified Hedgehog.Range             as Range
+
+kafkaEvent :: Gen KafkaEvent
+kafkaEvent = KafkaEvent
+  <$> eventSource
+  <*> Gen.maybe eventSourceArn
+  <*> bootstrapServers
+  <*> records
+
+eventSource :: Gen EventSource
+eventSource = Gen.enumBounded
+
+eventSourceArn :: Gen Text
+eventSourceArn = do
+  region <- Gen.element ["ap-south-1", "us-east-2", "eu-west-3"]
+  account <- Gen.text (Range.singleton 12) Gen.digit
+  clusterName <- Gen.text (Range.linear 1 20) printable
+  uuidParts <- for [ 7, 4, 4, 4, 12, 2 ] $ \n ->
+    Gen.text (Range.singleton n) Gen.hexit
+  let uuid = fold $ intersperse "-" uuidParts
+      resource = T.intercalate "/" ["cluster", clusterName, uuid]
+  pure $ T.intercalate ":" ["arn:aws:kafka", region, account, resource]
+
+bootstrapServers :: Gen (NonEmpty Text)
+bootstrapServers = Gen.nonEmpty (Range.linear 1 5) server
+  where
+    server :: Gen Text
+    server = (\h p -> h <> ":" <> p) <$> host <*> port
+
+    host :: Gen Text
+    host = fold . NE.intersperse "." <$> domainParts
+
+    domainParts :: Gen (NonEmpty Text)
+    domainParts = Gen.nonEmpty (Range.linear 1 5) fragment
+
+    fragment :: Gen Text
+    fragment = Gen.text (Range.linear 1 20) .
+      Gen.element $ ['A'..'Z'] <> ['a'..'z'] <> ['0'..'9'] <> ['-', '_']
+
+    port :: Gen Text
+    port = T.pack . show <$> Gen.int (Range.linear 0 65535)
+
+records :: Gen (Map Text [Record])
+records = Gen.map (Range.exponential 1 3)
+  . liftA2 (,) topicKey
+  $ Gen.list (Range.linear 1 5) record
+  where
+    topicKey :: Gen Text
+    topicKey = do
+      t <- topic
+      n <- T.pack . show <$> Gen.int (Range.linear 0 10)
+      pure $ t <> "-" <> n
+
+record :: Gen Record
+record = Record
+  <$> topic
+  <*> Gen.int32 (Range.exponential 0 maxBound)
+  <*> Gen.int64 (Range.linear 0 maxBound)
+  <*> timestamp
+  <*> headers
+  <*> Gen.maybe (Gen.bytes (Range.exponential 0 512))
+  <*> Gen.maybe (Gen.bytes (Range.exponential 0 512))
+
+timestamp :: Gen Timestamp
+timestamp = Gen.choice
+  [ pure NoTimestampType
+  , CreateTime <$> utcTime
+  , LogAppendTime <$> utcTime
+  ]
+  where
+    utcTime :: Gen UTCTime
+    utcTime = int64ToUTCTime <$> Gen.int64
+      (Range.exponentialFrom 1600000000000 1650000000000 1700000000000)
+
+headers :: Gen (Vector Header)
+headers = V.fromList <$> Gen.list (Range.linear 0 10)
+  (Header
+    <$> Gen.text (Range.linear 0 512) Gen.unicode
+    <*> Gen.bytes (Range.linear 0 512))
+
+topic :: Gen Text
+topic = Gen.text (Range.linear 1 20) printable
+
+printable :: Gen Char
+printable = Gen.filter isPrint Gen.ascii

--- a/test/AWS/Lambda/Events/Kafka/Gen.hs
+++ b/test/AWS/Lambda/Events/Kafka/Gen.hs
@@ -14,6 +14,7 @@ import           Data.List                  (intersperse)
 import qualified Data.List.NonEmpty         as NE
 import           Data.List.NonEmpty         (NonEmpty)
 import           Data.Map                   (Map)
+import           Data.Semigroup             ((<>))
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Time                  (UTCTime)

--- a/test/AWS/Lambda/Events/Kafka/Gen.hs
+++ b/test/AWS/Lambda/Events/Kafka/Gen.hs
@@ -19,8 +19,6 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Time                  (UTCTime)
 import           Data.Traversable           (for)
-import           Data.Vector
-import qualified Data.Vector                as V
 import           Hedgehog                   (Gen)
 import qualified Hedgehog.Gen               as Gen
 import qualified Hedgehog.Range             as Range
@@ -97,8 +95,8 @@ timestamp = Gen.choice
     utcTime = int64ToUTCTime <$> Gen.int64
       (Range.exponentialFrom 1600000000000 1650000000000 1700000000000)
 
-headers :: Gen (Vector Header)
-headers = V.fromList <$> Gen.list (Range.linear 0 10)
+headers :: Gen [Header]
+headers = Gen.list (Range.linear 0 10)
   (Header
     <$> Gen.text (Range.linear 0 512) Gen.unicode
     <*> Gen.bytes (Range.linear 0 512))

--- a/test/AWS/Lambda/Events/Kafka/Spec.hs
+++ b/test/AWS/Lambda/Events/Kafka/Spec.hs
@@ -30,7 +30,7 @@ spec = do
             `shouldBe` Right expectedSelfManagedKafkaPayload
 
     describe "properties" $ do
-        specify "KafkaEvent tripping" $
+        specify "tripping" $
             hedgehog $ do
                 request <- forAll Gen.kafkaEvent
                 tripping request encode decode

--- a/test/AWS/Lambda/Events/Kafka/Spec.hs
+++ b/test/AWS/Lambda/Events/Kafka/Spec.hs
@@ -20,7 +20,7 @@ import           Test.Hspec.Hedgehog         (hedgehog)
 import           Text.RawString.QQ           (r)
 
 spec :: Spec
-spec = describe "KafkaEvent" $ do
+spec = do
     specify "read MSK payload" $
         eitherDecode sampleMskPayload
             `shouldBe` Right expectedMskPayload

--- a/test/AWS/Lambda/Events/Kafka/Spec.hs
+++ b/test/AWS/Lambda/Events/Kafka/Spec.hs
@@ -12,8 +12,6 @@ import qualified Data.List.NonEmpty          as NE
 import qualified Data.Map                    as M
 import           Data.Time                   (UTCTime(..), fromGregorian,
                                               picosecondsToDiffTime)
-import           Data.Vector                 (Vector)
-import qualified Data.Vector                 as V
 import           Hedgehog                    (forAll, tripping)
 import           Test.Hspec                  (Spec, describe, shouldBe, specify)
 import           Test.Hspec.Hedgehog         (hedgehog)
@@ -84,7 +82,7 @@ expectedMskPayload = KafkaEvent
     ]
   , records = M.fromList
     [ ( "welcome-to-the-space-jam-0"
-      , [ withHeaders (V.singleton $ Header "headerKey" "headerValue")
+      , [ withHeaders [Header "headerKey" "headerValue"]
           . slamJamRecord 1
           $ UTCTime
               (fromGregorian 2021 05 18)
@@ -191,11 +189,11 @@ slamJamRecord off stamp = Record
   { topic = "welcome-to-the-space-jam"
   , partition = 0
   , offset = off
-  , headers = V.fromList []
+  , headers = []
   , timestamp = CreateTime stamp
   , key = Just "slam"
   , value = Just "jam"
   }
 
-withHeaders :: Vector Header -> Record -> Record
+withHeaders :: [Header] -> Record -> Record
 withHeaders headers record = record { headers }

--- a/test/AWS/Lambda/Events/Kafka/Spec.hs
+++ b/test/AWS/Lambda/Events/Kafka/Spec.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module AWS.Lambda.Events.Kafka.Spec where
+
+import           AWS.Lambda.Events.Kafka
+import qualified AWS.Lambda.Events.Kafka.Gen as Gen
+import           Data.Aeson                  (decode, eitherDecode, encode)
+import           Data.ByteString.Lazy        (ByteString)
+import           Data.Int                    (Int64)
+import qualified Data.List.NonEmpty          as NE
+import qualified Data.Map                    as M
+import           Data.Time                   (UTCTime(..), fromGregorian,
+                                              picosecondsToDiffTime)
+import           Data.Vector                 (Vector)
+import qualified Data.Vector                 as V
+import           Hedgehog                    (forAll, tripping)
+import           Test.Hspec                  (Spec, describe, shouldBe, specify)
+import           Test.Hspec.Hedgehog         (hedgehog)
+import           Text.RawString.QQ           (r)
+
+spec :: Spec
+spec = describe "KafkaEvent" $ do
+    specify "read MSK payload" $
+        eitherDecode sampleMskPayload
+            `shouldBe` Right expectedMskPayload
+
+    specify "read Self-Managed Kafka payload" $
+        eitherDecode sampleSelfManagedKafkaPayload
+            `shouldBe` Right expectedSelfManagedKafkaPayload
+
+    describe "properties" $ do
+        specify "KafkaEvent tripping" $
+            hedgehog $ do
+                request <- forAll Gen.kafkaEvent
+                tripping request encode decode
+
+sampleMskPayload :: ByteString
+sampleMskPayload = [r|
+{
+    "bootstrapServers": "b-1.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9094,b-2.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9094",
+    "eventSource": "aws:kafka",
+    "eventSourceArn": "arn:aws:kafka:us-east-1:123456789012:cluster/msk-test-cluster-2/669b9b55-48db-44e6-9c75-b9b9ab79ae36-14",
+    "records": {
+        "welcome-to-the-space-jam-0": [
+            {
+                "key": "c2xhbQ==",
+                "offset": 1,
+                "partition": 0,
+                "headers": [
+                    {
+                        "headerKey": [
+                            104,
+                            101,
+                            97,
+                            100,
+                            101,
+                            114,
+                            86,
+                            97,
+                            108,
+                            117,
+                            101
+                        ]
+                    }
+                ],
+                "timestamp": 1621304398263,
+                "timestampType": "CREATE_TIME",
+                "topic": "welcome-to-the-space-jam",
+                "value": "amFt"
+            }
+        ]
+    }
+}
+|]
+
+expectedMskPayload :: KafkaEvent
+expectedMskPayload = KafkaEvent
+  { eventSource = AwsKafka
+  , eventSourceArn = Just "arn:aws:kafka:us-east-1:123456789012:cluster/msk-test-cluster-2/669b9b55-48db-44e6-9c75-b9b9ab79ae36-14"
+  , bootstrapServers = NE.fromList
+    [ "b-1.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9094"
+    , "b-2.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9094"
+    ]
+  , records = M.fromList
+    [ ( "welcome-to-the-space-jam-0"
+      , [ withHeaders (V.singleton $ Header "headerKey" "headerValue")
+          . slamJamRecord 1
+          $ UTCTime
+              (fromGregorian 2021 05 18)
+              (picosecondsToDiffTime 8398263000000000)
+        ]
+      )
+    ]
+  }
+
+sampleSelfManagedKafkaPayload :: ByteString
+sampleSelfManagedKafkaPayload = [r|
+{
+    "bootstrapServers": "b-2.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9092,b-1.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9092",
+    "eventSource": "SelfManagedKafka",
+    "records": {
+        "welcome-to-the-space-jam-0": [
+            {
+                "key": "c2xhbQ==",
+                "offset": 0,
+                "partition": 0,
+                "headers": [],
+                "timestamp": 1621302644353,
+                "timestampType": "CREATE_TIME",
+                "topic": "welcome-to-the-space-jam",
+                "value": "amFt"
+            },
+            {
+                "key": "c2xhbQ==",
+                "offset": 1,
+                "partition": 0,
+                "headers": [],
+                "timestamp": 1621304398263,
+                "timestampType": "CREATE_TIME",
+                "topic": "welcome-to-the-space-jam",
+                "value": "amFt"
+            },
+            {
+                "key": "c2xhbQ==",
+                "offset": 2,
+                "partition": 0,
+                "headers": [],
+                "timestamp": 1621309340017,
+                "timestampType": "CREATE_TIME",
+                "topic": "welcome-to-the-space-jam",
+                "value": "amFt"
+            },
+            {
+                "key": "c2xhbQ==",
+                "offset": 3,
+                "partition": 0,
+                "headers": [],
+                "timestamp": 1621309352813,
+                "timestampType": "CREATE_TIME",
+                "topic": "welcome-to-the-space-jam",
+                "value": "amFt"
+            },
+            {
+                "key": "c2xhbQ==",
+                "offset": 4,
+                "partition": 0,
+                "headers": [],
+                "timestamp": 1621309372115,
+                "timestampType": "CREATE_TIME",
+                "topic": "welcome-to-the-space-jam",
+                "value": "amFt"
+            }
+        ]
+    }
+}
+|]
+
+expectedSelfManagedKafkaPayload :: KafkaEvent
+expectedSelfManagedKafkaPayload = KafkaEvent
+  { eventSource = SelfManagedKafka
+  , eventSourceArn = Nothing
+  , bootstrapServers = NE.fromList
+    [ "b-2.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9092"
+    , "b-1.msk-test-cluster-2.4jp6ci.c14.kafka.us-east-1.amazonaws.com:9092"
+    ]
+  , records = M.fromList
+    [ ( "welcome-to-the-space-jam-0"
+      , [ slamJamRecord 0 $ UTCTime
+            (fromGregorian 2021 05 18)
+            (picosecondsToDiffTime 6644353000000000)
+        , slamJamRecord 1 $ UTCTime
+            (fromGregorian 2021 05 18)
+            (picosecondsToDiffTime 8398263000000000)
+        , slamJamRecord 2 $ UTCTime
+            (fromGregorian 2021 05 18)
+            (picosecondsToDiffTime 13340017000000000)
+        , slamJamRecord 3 $ UTCTime
+            (fromGregorian 2021 05 18)
+            (picosecondsToDiffTime 13352813000000000)
+        , slamJamRecord 4 $ UTCTime
+            (fromGregorian 2021 05 18)
+            (picosecondsToDiffTime 13372115000000000)
+        ]
+      )
+    ]
+  }
+
+slamJamRecord :: Int64 -> UTCTime -> Record
+slamJamRecord off stamp = Record
+  { topic = "welcome-to-the-space-jam"
+  , partition = 0
+  , offset = off
+  , headers = V.fromList []
+  , timestamp = CreateTime stamp
+  , key = Just "slam"
+  , value = Just "jam"
+  }
+
+withHeaders :: Vector Header -> Record -> Record
+withHeaders headers record = record { headers }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -28,10 +28,10 @@ main :: IO ()
 main =
   hspec $ do
     describe "Events" $ do
-      describe "Kafka" Kafka.spec
       describe "ApiGateway" $ do
         describe "ProxyRequest" ProxyRequest.spec
         describe "ProxyResponse" ProxyResponse.spec
+      describe "Kafka" Kafka.spec
 
     describe "Event Response Data" $ do
       let staticContext =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,6 +5,7 @@ import           AWS.Lambda.Context                (ClientApplication (..),
 import qualified Gen.Header                        as Header
 import qualified AWS.Lambda.Events.ApiGateway.ProxyRequest.Gen as ProxyRequest
 import qualified AWS.Lambda.Events.ApiGateway.ProxyResponse.Gen as ProxyResponse
+import qualified AWS.Lambda.Events.Kafka.Spec      as Kafka
 import           AWS.Lambda.Internal               (StaticContext (..))
 import           AWS.Lambda.RuntimeClient.Internal (eventResponseToNextData)
 import           Data.Aeson                        (Value (Null), decode, encode)
@@ -25,6 +26,7 @@ import           Test.Hspec.Runner                 (hspec)
 main :: IO ()
 main =
   hspec $ do
+    describe "KafkaEvent" Kafka.spec
     describe "Event Response Data" $ do
       let staticContext =
             StaticContext


### PR DESCRIPTION
We've been using this internally for a few weeks now so it's probably worth thinking about upstreaming it.

Haven't done a package version bump and I expect many stack CIs to fail - we'll need to relax bounds once we know what the different LTSes want.

I also want to double-check that MSK event mappings provide a list of bootstrap brokers. The docs don't mention this but I'm pretty sure they did when I had a test cluster running.

Also: What else do we want to get into the next version? I'm happy to do up a PR for a default exception handler, and with `envy` still depending on `bytestring == 0.10.*` (and not having been updated for nearly a year), maybe we should prune it to remove a blocker on GHC9 support?