### PR TITLE
Drop Cabal GHC 8.0.2 support.

### DIFF
--- a/.github/workflows/haskell_cabal.yaml
+++ b/.github/workflows/haskell_cabal.yaml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         plan:
-          - ghc-version: '8.0.2'
-            cabal-version: '2.4'
           - ghc-version: '8.2.2'
             cabal-version: '2.4'
           - ghc-version: '8.4.4'


### PR DESCRIPTION
I'll put this back later if I can, but notably we don't support stack back this far anyway (would be LTS 9).  Current builds fail based on this issue here: https://github.com/haskell-foundation/foundation/issues/561.