### PR TITLE
Feature: log on invoke error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
   - Add `AWS.Lambda.Events.EventBridge.SSM.ParameterStoreChange` type
     for parsing AWS Systems Manager Parameter Store Change events
     delivered via AWS EventBridge.
+  - When the runtime encounters an error, write it out to the Cloudwatch logs
+    (via stderr), and do so in a format that can be guaranteed and later
+    extended.
 
 ## `0.4.9` - 2022-02-28
 

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -271,4 +271,4 @@ setRequestPath p req = req { path = p }
 -- specific formatting (similar to the Rust runtime).  But for now, not sure
 -- we'll ever see such an ask.
 logErrorMsg :: String -> IO ()
-logErrorMsg = hPutStrLn stderr . (<>) "ERROR " . show
+logErrorMsg = hPutStrLn stderr . (<>) "ERROR Message: " . show

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -23,7 +23,7 @@ import           Control.Applicative               ((<*>))
 import           Control.Concurrent                (threadDelay)
 import           Control.Exception                 (IOException, displayException,
                                                     throw, try)
-import           Control.Monad                     (unless)
+import           Control.Monad                     (unless, void)
 import           Control.Monad.IO.Class            (MonadIO, liftIO)
 import           Data.Aeson                        (Value, encode)
 import           Data.Aeson.Parser                 (value')
@@ -156,7 +156,8 @@ sendEventSuccess rcc@(RuntimeClientConfig baseRuntimeRequest manager _) reqId js
 sendEventError :: RuntimeClientConfig -> BS.ByteString -> String -> IO ()
 sendEventError (RuntimeClientConfig baseRuntimeRequest manager _) reqId e = do
   logErrorMsg e
-  fmap (const ()) $ runtimeClientRetry $ flip httpNoBody manager $ toEventErrorRequest reqId e baseRuntimeRequest
+  let request = httpNoBody (toEventErrorRequest reqId e baseRuntimeRequest) manager
+  void $ runtimeClientRetry request
 
 sendInitError :: Request -> Manager -> String -> IO ()
 sendInitError baseRuntimeRequest manager e =


### PR DESCRIPTION
Fixes #100.  After discussion there, logging errors appear to be standard practice in custom runtimes, and doesn't pose any risks of leaking information than is already present (returning errors to the invoking entity seems much more concerning, and that always happens regardless).

There's no standard or recommendation across runtimes, so this aims to just fit in nicely to other AWS Lambda standard messaging.  This should be parse-able in a similar way:  all caps tag followed by key value pairs separated by tabs (only `Message` will be present today, but that lets us extend later).  Since users may parse this data, its format likely needs to be considered under contract.