### PR TITLE
CHANGELOG.md: correct module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
 
   - Add `AWS.Lambda.Events.EventBridge.EventBridgeEvent` type for
     subscribing Lambda functions to AWS EventBridge Events
-  - Add `AWS.Lambda.Events.EventBridge.SSM.ParameterStoreChange` type
-    for parsing AWS Systems Manager Parameter Store Change events
+  - Add `AWS.Lambda.Events.EventBridge.Detail.SSM.ParameterStoreChange`
+    type for parsing AWS Systems Manager Parameter Store Change events
     delivered via AWS EventBridge.
   - When the runtime encounters an error, write it out to the Cloudwatch logs
     (via stderr), and do so in a format that can be guaranteed and later

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
+## Unreleased
+
+  - `instance FromJSON AWS.Lambda.Events.EventBridge.Detail.SSM.ParameterStoreChange.Operation`
+    now accepts arbitrary `Text` instead of the four currently-known
+    operations.
+
 ## `0.4.10` - 2022-03-22
 
   - Add `AWS.Lambda.Events.EventBridge.EventBridgeEvent` type for

--- a/src/AWS/Lambda/Events/EventBridge/Detail/SSM/ParameterStoreChange.hs
+++ b/src/AWS/Lambda/Events/EventBridge/Detail/SSM/ParameterStoreChange.hs
@@ -97,12 +97,7 @@ pattern LabelParameterVersion = Operation "LabelParameterVersion"
 {-# COMPLETE Create, Update, Delete, LabelParameterVersion #-}
 
 instance FromJSON Operation where
-  parseJSON = withText "Operation" $ \case
-    "Create" -> pure Create
-    "Update" -> pure Update
-    "Delete" -> pure Delete
-    "LabelParameterVersion" -> pure LabelParameterVersion
-    t -> fail $ "Unrecognized operation: " ++ show t
+  parseJSON = withText "Operation" $ pure . Operation
 
 instance ToJSON Operation where
   toJSON (Operation op) = Aeson.String op


### PR DESCRIPTION
I forgot to fix the changelog when I moved the `ParameterStoreChange` module under `Detail`. While it's not worth another release, the changelog can at least be correct in future versions.