### PR TITLE
Extend supported versions to newer versions of GHC

### DIFF
--- a/.github/workflows/haskell_cabal.yaml
+++ b/.github/workflows/haskell_cabal.yaml
@@ -19,6 +19,14 @@ jobs:
             cabal-version: '2.4'
           - ghc-version: '8.8'
             cabal-version: '3.0'
+          - ghc-version: '8.10.7'
+            cabal-version: '3.0'
+          - ghc-version: '9.0.2'
+            cabal-version: '3.0'
+          - ghc-version: '9.2.4'
+            cabal-version: '3.0'
+          - ghc-version: '9.4.2'
+            cabal-version: '3.0'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/haskell_stack.yaml
+++ b/.github/workflows/haskell_stack.yaml
@@ -21,6 +21,8 @@ jobs:
           - lts-15
           - lts-16
           - lts-17
+          - lts-18
+          - lts-19
         experimental:
           - false
         include:

--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6db9f32350cdd6e49054d6fb475e90c464a07aa86ea3ae1a9b773772e9044aa3
+-- hash: 675d226101332b6bbf9f10dbadac03bf421abfb2253542bf48aed3623036bf28
 
 name:           hal
 version:        1.0.0
@@ -58,6 +58,7 @@ library
       DeriveGeneric
       DeriveLift
       DeriveTraversable
+      DisambiguateRecordFields
       DuplicateRecordFields
       EmptyCase
       GeneralizedNewtypeDeriving
@@ -117,6 +118,7 @@ test-suite hal-test
       DeriveGeneric
       DeriveLift
       DeriveTraversable
+      DisambiguateRecordFields
       DuplicateRecordFields
       EmptyCase
       GeneralizedNewtypeDeriving

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ default-extensions:
   - DeriveGeneric
   - DeriveLift
   - DeriveTraversable
+  - DisambiguateRecordFields
   - DuplicateRecordFields
   - EmptyCase
   - GeneralizedNewtypeDeriving

--- a/src/AWS/Lambda/Events/ApiGateway/ProxyRequest.hs
+++ b/src/AWS/Lambda/Events/ApiGateway/ProxyRequest.hs
@@ -93,21 +93,24 @@ instance FromJSON a => FromJSON (RequestContext a) where
 
 -- | @since 0.4.8
 instance ToJSON a => ToJSON (RequestContext a) where
-    toJSON r = object $ catMaybes
-        [ Just $ "path" .= path (r :: RequestContext a)
-        , Just $ "accountId" .= accountId (r :: RequestContext a)
-        , ("authorizer" .=) <$> authorizer r
-        , Just $ "resourceId" .= resourceId r
-        , Just $ "stage" .= stage r
-        , ("domainPrefix" .=) <$> domainPrefix r
-        , Just $ "requestId" .= requestId r
-        , Just $ "identity" .= identity r
-        , ("domainName" .=) <$> domainName r
-        , Just $ "resourcePath" .= resourcePath r
-        , Just $ "httpMethod" .= httpMethod (r :: RequestContext a)
-        , ("extendedRequestId" .=) <$> extendedRequestId r
-        , Just $ "apiId" .= apiId r
-        ]
+    toJSON r = object $ catMaybes $
+        let
+            RequestContext { path = p, accountId = a, httpMethod = h } = r
+        in
+            [ Just $ "path" .= p
+            , Just $ "accountId" .= a
+            , ("authorizer" .=) <$> authorizer r
+            , Just $ "resourceId" .= resourceId r
+            , Just $ "stage" .= stage r
+            , ("domainPrefix" .=) <$> domainPrefix r
+            , Just $ "requestId" .= requestId r
+            , Just $ "identity" .= identity r
+            , ("domainName" .=) <$> domainName r
+            , Just $ "resourcePath" .= resourcePath r
+            , Just $ "httpMethod" .= h
+            , ("extendedRequestId" .=) <$> extendedRequestId r
+            , Just $ "apiId" .= apiId r
+            ]
 
 -- TODO: Should also include websocket fields
 -- | This type is for representing events that come from API Gateway via the
@@ -203,24 +206,27 @@ instance FromJSON a => FromJSON (ProxyRequest a) where
 
 -- | @since 0.4.8
 instance ToJSON a => ToJSON (ProxyRequest a) where
-    toJSON r = object $ catMaybes
-        [ Just $ "path" .= path (r :: ProxyRequest a)
-        , toMaybe (not . null $ headers r) $
-              "headers" .= fromCIHashMap (headers r)
-        , toMaybe (not . null $ multiValueHeaders r) $
-              "multiValueHeaders" .= fromCIHashMap (multiValueHeaders r)
-        , toMaybe (not . null $ pathParameters r) $
-              "pathParameters" .= pathParameters r
-        , toMaybe (not . null $ stageVariables r) $
-              "stageVariables" .= stageVariables r
-        , Just $ "requestContext" .= requestContext r
-        , Just $ "resource" .= resource r
-        , Just $ "httpMethod" .= httpMethod (r :: ProxyRequest a)
-        , toMaybe (not . null $ queryStringParameters r) $
-              "queryStringParameters" .= queryStringParameters r
-        , toMaybe (not . null $ multiValueQueryStringParameters r) $
-              "multiValueQueryStringParameters" .=
-                  multiValueQueryStringParameters r
-        , Just $ "isBase64Encoded" .= True
-        , Just $ "body" .= TLE.decodeUtf8 (encode (body r))
-        ]
+    toJSON r = object $ catMaybes $
+        let
+            ProxyRequest { path = p, httpMethod = h } = r
+        in
+            [ Just $ "path" .= p
+            , toMaybe (not . null $ headers r) $
+                  "headers" .= fromCIHashMap (headers r)
+            , toMaybe (not . null $ multiValueHeaders r) $
+                  "multiValueHeaders" .= fromCIHashMap (multiValueHeaders r)
+            , toMaybe (not . null $ pathParameters r) $
+                  "pathParameters" .= pathParameters r
+            , toMaybe (not . null $ stageVariables r) $
+                  "stageVariables" .= stageVariables r
+            , Just $ "requestContext" .= requestContext r
+            , Just $ "resource" .= resource r
+            , Just $ "httpMethod" .= h
+            , toMaybe (not . null $ queryStringParameters r) $
+                  "queryStringParameters" .= queryStringParameters r
+            , toMaybe (not . null $ multiValueQueryStringParameters r) $
+                  "multiValueQueryStringParameters" .=
+                      multiValueQueryStringParameters r
+            , Just $ "isBase64Encoded" .= True
+            , Just $ "body" .= TLE.decodeUtf8 (encode (body r))
+            ]

--- a/stack-lts-18.yaml
+++ b/stack-lts-18.yaml
@@ -1,0 +1,4 @@
+resolver: lts-18.28
+packages:
+- .
+extra-deps: []

--- a/stack-lts-19.yaml
+++ b/stack-lts-19.yaml
@@ -1,0 +1,4 @@
+resolver: lts-19.32
+packages:
+- .
+extra-deps: []


### PR DESCRIPTION
Stack LTS 18 and LTS 19 and GHC 9.0, 9.2, and 9.4 with Cabal.

Fixes #114 