### PR TITLE
Fix constraint kind when building with newer versions of aeson

### DIFF
--- a/hal.cabal
+++ b/hal.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c2102a6f40dd25d65f83e2241326f8ea79792997022f6f22c86423298c126ce0
+-- hash: a7d2d74bc456fafb4d0404d66bf75f0c0eb18a92a3455cb116d60cd8229be1e0
 
 name:           hal
 version:        1.0.0.1
@@ -71,7 +71,7 @@ library
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
-      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
+      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.3.0.0
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring
@@ -131,7 +131,7 @@ test-suite hal-test
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.1.0
+      aeson
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring

--- a/hal.cabal
+++ b/hal.cabal
@@ -131,7 +131,7 @@ test-suite hal-test
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson
+      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.1.0
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -55,7 +55,7 @@ ghc-options:
 library:
   source-dirs: src
   dependencies:
-    - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
+    - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.3.0.0
     - base64-bytestring
     - bytestring
     - case-insensitive

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -253,7 +253,11 @@ parseTimestamp o = explicitParseField parseSubtype o "timestampType"
       int64ToUTCTime <$> (toBoundedInteger stamp &
         maybe (fail "timestamp out of range") pure :: Parser Int64)
 
+#if MIN_VERSION_aeson(2,2,0)
+unparseTimestamp :: KeyValue e kv => Timestamp -> [kv]
+#else
 unparseTimestamp :: KeyValue kv => Timestamp -> [kv]
+#endif
 unparseTimestamp = \case
   NoTimestampType -> ["timestampType" .= String "NO_TIMESTAMP_TYPE"]
   CreateTime ts ->


### PR DESCRIPTION
The definition of `KeyValue` changed in aeson 2.2.0.0 and has a different constraint kind. This fixes the compilation error in `unparseTimestamp`
