### PR TITLE
Add support for aeson 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
+## unreleased - 2023-07-06
+
+  - Add support for aeson 2.2
+
 ## `1.0.0.1` - 2022-09-10
 
   - Support GHC 9.4 by eliminating compiler errors

--- a/hal.cabal
+++ b/hal.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c2102a6f40dd25d65f83e2241326f8ea79792997022f6f22c86423298c126ce0
+-- hash: 859c2960ede07f248b902fe2c54014c0204d05da719c7182305e34e6d34f6728
 
 name:           hal
 version:        1.0.0.1
@@ -71,7 +71,8 @@ library
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
-      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
+      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.3.0.0
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring
@@ -138,7 +139,7 @@ test-suite hal-test
     , case-insensitive
     , containers
     , hal
-    , hedgehog >=1.0.3 && <1.2
+    , hedgehog >=1.0.3 && <1.3
     , hspec
     , hspec-hedgehog
     , http-client
@@ -149,5 +150,5 @@ test-suite hal-test
     , time
     , transformers
     , unordered-containers
-    , vector >=0.12.0.0 && <0.13
+    , vector >=0.12.0.0 && <0.14.0.0
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -55,7 +55,8 @@ ghc-options:
 library:
   source-dirs: src
   dependencies:
-    - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
+    - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.3.0.0
+    - attoparsec-aeson
     - base64-bytestring
     - bytestring
     - case-insensitive
@@ -87,7 +88,7 @@ tests:
     - bytestring
     - case-insensitive
     - containers
-    - hedgehog >= 1.0.3 && < 1.2
+    - hedgehog >= 1.0.3 && < 1.3
     - hspec
     - hspec-hedgehog
     - http-client
@@ -98,4 +99,4 @@ tests:
     - time
     - transformers
     - unordered-containers
-    - vector ^>=0.12.0.0
+    - vector >=0.12.0.0 && < 0.14.0.0

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -253,7 +253,11 @@ parseTimestamp o = explicitParseField parseSubtype o "timestampType"
       int64ToUTCTime <$> (toBoundedInteger stamp &
         maybe (fail "timestamp out of range") pure :: Parser Int64)
 
+#if MIN_VERSION_aeson(2,2,0)
+unparseTimestamp :: KeyValue e kv => Timestamp -> [kv]
+#else
 unparseTimestamp :: KeyValue kv => Timestamp -> [kv]
+#endif
 unparseTimestamp = \case
   NoTimestampType -> ["timestampType" .= String "NO_TIMESTAMP_TYPE"]
   CreateTime ts ->


### PR DESCRIPTION
Do not merge until `attoparsec-aeson` has a compat package on Hackage