### PR TITLE
Drop 8.2.2 for Cabal add lts 20

### DIFF
--- a/.github/workflows/haskell_cabal.yaml
+++ b/.github/workflows/haskell_cabal.yaml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         plan:
-          - ghc-version: '8.2.2'
-            cabal-version: '2.4'
           - ghc-version: '8.4.4'
             cabal-version: '2.4'
           - ghc-version: '8.8'

--- a/.github/workflows/haskell_stack.yaml
+++ b/.github/workflows/haskell_stack.yaml
@@ -23,6 +23,7 @@ jobs:
           - lts-17
           - lts-18
           - lts-19
+          - lts-20
         experimental:
           - false
         include:

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -1,0 +1,4 @@
+resolver: lts-20.26
+packages:
+- .
+extra-deps: []


### PR DESCRIPTION
Our GIthub action can no longer install GHC 8.2.2, so this is causing false negatives.  Long term, i'd like to explore using something like nix to address this.

While here, we add support for stack LTS 20.  LTS 21 involves extending test dependency constraints, which currently is going to cause some merge conflict noise.