### PR TITLE
Use a flag to set whether or not we use aeson-2.2 and attoparsec-aeso…

### DIFF
--- a/hal.cabal
+++ b/hal.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 69b9493ccccd06a12d2fb93eb5595886de8807c16244084959ecfe90b73eab13
+-- hash: d8620c73a5fa1420a588e2d7fd6ac5d10500c751d2d88d05b1b4d0ce44d45883
 
 name:           hal
 version:        1.0.0.1
@@ -28,6 +28,11 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/Nike-inc/hal
+
+flag use-aeson-2-2
+  description: Required parsers are split out into a different package
+  manual: False
+  default: True
 
 library
   exposed-modules:
@@ -71,9 +76,7 @@ library
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
-      aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.3.0.0
-    , attoparsec-aeson
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , base64-bytestring
     , bytestring
     , case-insensitive
@@ -90,6 +93,13 @@ library
     , time
     , unordered-containers
   default-language: Haskell2010
+  if flag(use-aeson-2-2)
+    build-depends:
+        aeson >=2.2.0.0 && <2.3.0.0
+      , attoparsec-aeson
+  else
+    build-depends:
+        aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
 
 test-suite hal-test
   type: exitcode-stdio-1.0

--- a/package.yaml
+++ b/package.yaml
@@ -52,11 +52,15 @@ ghc-options:
   - -fwarn-missing-signatures
   - -fwarn-incomplete-patterns
 
+flags:
+  use-aeson-2-2:
+    description: Required parsers are split out into a different package
+    default: true
+    manual: false
+
 library:
   source-dirs: src
   dependencies:
-    - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.3.0.0
-    - attoparsec-aeson
     - base64-bytestring
     - bytestring
     - case-insensitive
@@ -72,6 +76,15 @@ library:
     - text
     - time
     - unordered-containers
+  when:
+    - condition: flag(use-aeson-2-2)
+      then:
+        dependencies:
+          - aeson >=2.2.0.0 && <2.3.0.0
+          - attoparsec-aeson
+      else:
+        dependencies:
+          - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
 
 tests:
   hal-test:

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,8 +1,10 @@
 resolver: lts-13.30
 packages:
 - .
+flags:
+  hal:
+    use-aeson-2-2: false
 extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
 - hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - hspec-2.7.1@sha256:0aa48928ce80a34f8ff8c5ef114bb6807edfb8d884bcd7211eceed710e7fb7a8,1769
 - hspec-core-2.7.1@sha256:ead64b6d552e477549624fc9de3658657faac0dabf7109f889d595be05547bbf,4594

--- a/stack-lts-13.yaml.lock
+++ b/stack-lts-13.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-- completed:
     hackage: hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
     pantry-tree:
       size: 2575

--- a/stack-lts-14.yaml
+++ b/stack-lts-14.yaml
@@ -1,7 +1,9 @@
 resolver: lts-14.27
 packages:
 - .
+flags:
+  hal:
+    use-aeson-2-2: false
 extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
 - hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - hspec-hedgehog-0.0.1.2@sha256:4d09c7be34cdc941b78e4e964f71013ffeeb099ea32d8ede17ad9c03ae7a62e3,1470

--- a/stack-lts-14.yaml.lock
+++ b/stack-lts-14.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-- completed:
     hackage: hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
     pantry-tree:
       size: 2575

--- a/stack-lts-15.yaml
+++ b/stack-lts-15.yaml
@@ -1,7 +1,9 @@
 resolver: lts-15.16
 packages:
 - .
+flags:
+  hal:
+    use-aeson-2-2: false
 extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
 - hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - hspec-hedgehog-0.0.1.2@sha256:4d09c7be34cdc941b78e4e964f71013ffeeb099ea32d8ede17ad9c03ae7a62e3,1470

--- a/stack-lts-15.yaml.lock
+++ b/stack-lts-15.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-- completed:
     hackage: hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
     pantry-tree:
       size: 2575

--- a/stack-lts-16.yaml
+++ b/stack-lts-16.yaml
@@ -1,5 +1,6 @@
 resolver: lts-16.31
 packages:
 - .
-extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+flags:
+  hal:
+    use-aeson-2-2: false

--- a/stack-lts-16.yaml.lock
+++ b/stack-lts-16.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+packages: []
 snapshots:
 - completed:
     size: 534126

--- a/stack-lts-17.yaml
+++ b/stack-lts-17.yaml
@@ -1,5 +1,6 @@
 resolver: lts-17.10
 packages:
 - .
-extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+flags:
+  hal:
+    use-aeson-2-2: false

--- a/stack-lts-17.yaml.lock
+++ b/stack-lts-17.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+packages: []
 snapshots:
 - completed:
     size: 567241

--- a/stack-lts-18.yaml
+++ b/stack-lts-18.yaml
@@ -1,5 +1,6 @@
 resolver: lts-18.28
 packages:
 - .
-extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+flags:
+  hal:
+    use-aeson-2-2: false

--- a/stack-lts-19.yaml
+++ b/stack-lts-19.yaml
@@ -1,5 +1,6 @@
 resolver: lts-19.32
 packages:
 - .
-extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+flags:
+  hal:
+    use-aeson-2-2: false

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -1,5 +1,6 @@
 resolver: lts-20.26
 packages:
 - .
-extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+flags:
+  hal:
+    use-aeson-2-2: false

--- a/stack-lts-21.yaml
+++ b/stack-lts-21.yaml
@@ -1,5 +1,6 @@
 resolver: lts-21.14
 packages:
 - .
-extra-deps:
-- attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+flags:
+  hal:
+    use-aeson-2-2: false

--- a/stack-lts-21.yaml.lock
+++ b/stack-lts-21.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
+packages: []
 snapshots:
 - completed:
     sha256: 60e54c1ba3c1e7163acf6dafa9d56b2d3b23f88a31ad53a1c9d888f32561f8da


### PR DESCRIPTION
…n, instead of using the compatibility package.