### PR TITLE
Fix error handling in pure runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
 
 ## unreleased - 2023-11-23
 
-  - Add support for aeson 2.2
-  - `fallibleRuntime` and `fallibleRuntimeWithContext` reports errors to AWS
+  - `fallibleRuntime` and `fallibleRuntimeWithContext` report errors to AWS
     instead of returning `{"Left": "some error"}`.
   - `fallibleRuntime` and `fallibleRuntimeWithContext` no longer wrap their
-    successful responses in `{"Right": ...}`
+    successful responses in `{"Right": ...}`.
   - `pureRuntime`, `pureRuntimeWithContext`, `fallibleRuntime` and `fallibleRuntimeWithContext`
     no longer crash the Lambda runtime if input can't be parsed from JSON.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
-## unreleased - 2023-07-06
+## unreleased - 2023-11-23
 
   - Add support for aeson 2.2
+  - `fallibleRuntime` and `fallibleRuntimeWithContext` reports errors to AWS
+    instead of returning `{"Left": "some error"}`.
+  - `pureRuntime`, `pureRuntimeWithContext`, `fallibleRuntime` and `fallibleRuntimeWithContext`
+    no longer crash the Lambda runtime if input can't be parsed from JSON.
 
 ## `1.0.0.1` - 2022-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
   - Add support for aeson 2.2
   - `fallibleRuntime` and `fallibleRuntimeWithContext` reports errors to AWS
     instead of returning `{"Left": "some error"}`.
+  - `fallibleRuntime` and `fallibleRuntimeWithContext` no longer wrap their
+    successful responses in `{"Right": ...}`
   - `pureRuntime`, `pureRuntimeWithContext`, `fallibleRuntime` and `fallibleRuntimeWithContext`
     no longer crash the Lambda runtime if input can't be parsed from JSON.
 

--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -17,8 +17,8 @@ module AWS.Lambda.Combinators (
     withFallibleParse
 ) where
 
-import           Data.Aeson       (FromJSON, Value, parseJSON)
-import           Data.Aeson.Types (parseEither)
+import           Data.Aeson             (FromJSON, parseJSON, Value)
+import           Data.Aeson.Types       (parseEither)
 
 -- | An alias of 'const', this upgrades a handler that does not accept
 -- 'AWS.Lambda.Context.LambdaContext' as its first curried argument to one that does.

--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -14,7 +14,7 @@ They map functions (instead of values) to turn basic handlers into handlers comp
 module AWS.Lambda.Combinators (
     withoutContext,
     withInfallibleParse,
-    withInfallibleParseEither
+    withFallibleParse
 ) where
 
 import           Data.Aeson       (FromJSON, Value, parseJSON)
@@ -72,5 +72,6 @@ withoutContext = const
 withInfallibleParse :: FromJSON a => (a -> b) -> Value -> b
 withInfallibleParse fn = either error fn . parseEither parseJSON
 
-withInfallibleParseEither :: FromJSON a => (a -> b) -> Value -> Either String b
-withInfallibleParseEither fn = fmap fn . parseEither parseJSON
+-- | Like 'withInfallibleParse', but return the result in an 'Either' instead of using 'error'.
+withFallibleParse :: FromJSON a => (a -> b) -> Value -> Either String b
+withFallibleParse fn = fmap fn . parseEither parseJSON

--- a/src/AWS/Lambda/Combinators.hs
+++ b/src/AWS/Lambda/Combinators.hs
@@ -13,11 +13,12 @@ They map functions (instead of values) to turn basic handlers into handlers comp
 
 module AWS.Lambda.Combinators (
     withoutContext,
-    withInfallibleParse
+    withInfallibleParse,
+    withInfallibleParseEither
 ) where
 
-import           Data.Aeson             (FromJSON, parseJSON, Value)
-import           Data.Aeson.Types       (parseEither)
+import           Data.Aeson       (FromJSON, Value, parseJSON)
+import           Data.Aeson.Types (parseEither)
 
 -- | An alias of 'const', this upgrades a handler that does not accept
 -- 'AWS.Lambda.Context.LambdaContext' as its first curried argument to one that does.
@@ -70,3 +71,6 @@ withoutContext = const
 -- on a failure to convert the JSON AST sent to the Lambda.
 withInfallibleParse :: FromJSON a => (a -> b) -> Value -> b
 withInfallibleParse fn = either error fn . parseEither parseJSON
+
+withInfallibleParseEither :: FromJSON a => (a -> b) -> Value -> Either String b
+withInfallibleParseEither fn = fmap fn . parseEither parseJSON

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NamedFieldPuns, OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+
 
 {-|
 Module      : AWS.Lambda.Context
@@ -21,8 +22,8 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Aeson             (FromJSON, ToJSON)
 import           Data.Map               (Map)
 import           Data.Text              (Text)
-import           Data.Time.Clock        (DiffTime, UTCTime,
-                                         diffUTCTime, getCurrentTime)
+import           Data.Time.Clock        (DiffTime, UTCTime, diffUTCTime,
+                                         getCurrentTime)
 import           GHC.Generics           (Generic)
 
 data ClientApplication = ClientApplication

--- a/src/AWS/Lambda/Context.hs
+++ b/src/AWS/Lambda/Context.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE NamedFieldPuns    #-}
-
+{-# LANGUAGE NamedFieldPuns #-}
 
 {-|
 Module      : AWS.Lambda.Context
@@ -22,8 +21,8 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Aeson             (FromJSON, ToJSON)
 import           Data.Map               (Map)
 import           Data.Text              (Text)
-import           Data.Time.Clock        (DiffTime, UTCTime, diffUTCTime,
-                                         getCurrentTime)
+import           Data.Time.Clock        (DiffTime, UTCTime,
+                                         diffUTCTime, getCurrentTime)
 import           GHC.Generics           (Generic)
 
 data ClientApplication = ClientApplication

--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -321,7 +321,7 @@ fallibleRuntime = fallibleRuntimeWithContext . withoutContext
 -- @
 pureRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> result) -> IO ()
-pureRuntimeWithContext fn = ValueRuntime.fallibleRuntimeWithContext $ withFallibleParse . fn
+pureRuntimeWithContext = fallibleRuntimeWithContext . fmap (fmap pure)
 
 -- | For pure functions that can never fail.
 --

--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -30,7 +30,7 @@ module AWS.Lambda.Runtime (
 ) where
 
 import           AWS.Lambda.Combinators   (withInfallibleParse,
-                                           withInfallibleParseEither,
+                                           withFallibleParse,
                                            withoutContext)
 import           AWS.Lambda.Context       (LambdaContext (..))
 import qualified AWS.Lambda.Runtime.Value as ValueRuntime
@@ -256,7 +256,7 @@ ioRuntime = ValueRuntime.ioRuntime . withInfallibleParse
 -- @
 fallibleRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> Either String result) -> IO ()
-fallibleRuntimeWithContext fn = ValueRuntime.fallibleRuntimeWithContext $ \lc -> join . withInfallibleParseEither (fn lc)
+fallibleRuntimeWithContext fn = ValueRuntime.fallibleRuntimeWithContext $ \lc -> join . withFallibleParse (fn lc)
 
 -- | For pure functions that can still fail.
 --
@@ -321,7 +321,7 @@ fallibleRuntime = fallibleRuntimeWithContext . withoutContext
 -- @
 pureRuntimeWithContext :: (FromJSON event, ToJSON result) =>
   (LambdaContext -> event -> result) -> IO ()
-pureRuntimeWithContext fn = ValueRuntime.fallibleRuntimeWithContext $ withInfallibleParseEither . fn
+pureRuntimeWithContext fn = ValueRuntime.fallibleRuntimeWithContext $ withFallibleParse . fn
 
 -- | For pure functions that can never fail.
 --

--- a/src/AWS/Lambda/Runtime.hs
+++ b/src/AWS/Lambda/Runtime.hs
@@ -32,7 +32,7 @@ module AWS.Lambda.Runtime (
 import           AWS.Lambda.Combinators   (withInfallibleParse,
                                            withFallibleParse,
                                            withoutContext)
-import           AWS.Lambda.Context       (LambdaContext (..))
+import           AWS.Lambda.Context       (LambdaContext(..))
 import qualified AWS.Lambda.Runtime.Value as ValueRuntime
 import           Control.Monad            (join)
 import           Control.Monad.Catch      (MonadCatch)

--- a/src/AWS/Lambda/Runtime/Value.hs
+++ b/src/AWS/Lambda/Runtime/Value.hs
@@ -40,12 +40,12 @@ module AWS.Lambda.Runtime.Value (
 ) where
 
 import           AWS.Lambda.Combinators   (withoutContext)
-import           AWS.Lambda.Context       (LambdaContext (..))
+import           AWS.Lambda.Context       (LambdaContext(..))
 import           AWS.Lambda.RuntimeClient (RuntimeClientConfig, getNextData,
                                            getRuntimeClientConfig,
                                            sendEventError, sendEventSuccess)
 import           Control.Exception        (SomeException, displayException)
-import           Control.Monad            (forever, (<=<))
+import           Control.Monad            ((<=<), forever)
 import           Control.Monad.Catch      (MonadCatch, try)
 import           Control.Monad.IO.Class   (MonadIO, liftIO)
 import           Control.Monad.Reader     (ReaderT, runReaderT)

--- a/src/AWS/Lambda/Runtime/Value.hs
+++ b/src/AWS/Lambda/Runtime/Value.hs
@@ -39,12 +39,13 @@ module AWS.Lambda.Runtime.Value (
   mRuntimeWithContext,
 ) where
 
-import           AWS.Lambda.RuntimeClient (RuntimeClientConfig, getRuntimeClientConfig,
-                                           getNextData, sendEventError, sendEventSuccess)
 import           AWS.Lambda.Combinators   (withoutContext)
-import           AWS.Lambda.Context       (LambdaContext(..))
+import           AWS.Lambda.Context       (LambdaContext (..))
+import           AWS.Lambda.RuntimeClient (RuntimeClientConfig, getNextData,
+                                           getRuntimeClientConfig,
+                                           sendEventError, sendEventSuccess)
 import           Control.Exception        (SomeException, displayException)
-import           Control.Monad            ((<=<), forever)
+import           Control.Monad            (forever, (<=<))
 import           Control.Monad.Catch      (MonadCatch, try)
 import           Control.Monad.IO.Class   (MonadIO, liftIO)
 import           Control.Monad.Reader     (ReaderT, runReaderT)
@@ -331,7 +332,7 @@ ioRuntime = ioRuntimeWithContext . withoutContext
 -- @
 fallibleRuntimeWithContext :: ToJSON result =>
   (LambdaContext -> Value -> Either String result) -> IO ()
-fallibleRuntimeWithContext = mRuntimeWithContext . fmap (fmap pure)
+fallibleRuntimeWithContext fn = mRuntimeWithContext (\lc -> either error pure . fn lc)
 
 -- | For pure functions that can still fail.
 --


### PR DESCRIPTION
There were two problems with pure runtimes:
1. When returning `Left` from `fallibleRuntime`, `Left` appears literally in the response, and the lambda function exit successfully
2. If the input can't be parsed from json, the error won't be caught properly. The error message will only appear in CloudWatch logs, but not reported back to AWS Lambda. Thus, it's hard for caller to determine what error happened. Fixes #108

Screenshot for the two problems, respectively:
<img width="500" src="https://github.com/Nike-Inc/hal/assets/16440269/6407d638-51de-4fc5-bab3-9520ba71a2e4">
<img width="567" alt="image" src="https://github.com/Nike-Inc/hal/assets/16440269/2bf19843-8685-4134-928e-1ee35c2766f9">

Reasons for these problems:
1. We didn't handle `Either` in `falliableRuntimeWithContext`
```haskell
fallibleRuntimeWithContext :: ToJSON result =>
  (LambdaContext -> Value -> Either String result) -> IO ()
fallibleRuntimeWithContext = mRuntimeWithContext . fmap (fmap pure)

pureRuntimeWithContext :: ToJSON result =>
  (LambdaContext -> Value -> result) -> IO ()
pureRuntimeWithContext = mRuntimeWithContext . fmap (fmap pure)
```
`Either String result` wasn't handled, and it was treated as a `ToJSON` value as a whole.

2. In `withInfallibleParse fn = either error fn . parseEither parseJSON`, the `Left` side of `Either` was thrown by `error` in a pure context. When we later call `try`, the value is still lazy and possibly not evaluated.

This PR addresses both problems.