### PR TITLE
Fix sqs message attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
 
 ## Unreleased
   - Add `messageGroupId` to SQS Attributes.
+  - Fix the type of `messageAttributes` in `SQSEvent`.
 
 ## `1.1` - 2023-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
 
 ## Unreleased
   - Add `messageGroupId` to SQS Attributes.
+  - Fix header parsing to accept `null` values serialised as `{}` 
 
 ## `1.1` - 2023-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
+## Unreleased
+  - Add `messageGroupId` to SQS Attributes.
+
 ## `1.1` - 2023-12-18
 
   - `fallibleRuntime` and `fallibleRuntimeWithContext` report errors to AWS

--- a/hal.cabal
+++ b/hal.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 68071e7a76bb7ee4441cd578bc9de2a1c3ffb2622ab059ce676d816922ed3d4b
+-- hash: a8f1e61978a7c0772b00f7d79b8d54b83646f1aac9da8e964f32057442567c95
 
 name:           hal
 version:        1.1
@@ -116,6 +116,7 @@ test-suite hal-test
       AWS.Lambda.Events.EventBridge.Spec
       AWS.Lambda.Events.Kafka.Gen
       AWS.Lambda.Events.Kafka.Spec
+      AWS.Lambda.Events.SQS.Spec
       Gen.Header
       Paths_hal
   hs-source-dirs:
@@ -149,7 +150,7 @@ test-suite hal-test
     , case-insensitive
     , containers
     , hal
-    , hedgehog >=1.0.3 && <1.5
+    , hedgehog >=1.0.3 && <1.8
     , hspec
     , hspec-hedgehog
     , http-client

--- a/package.yaml
+++ b/package.yaml
@@ -101,7 +101,7 @@ tests:
     - bytestring
     - case-insensitive
     - containers
-    - hedgehog >= 1.0.3 && < 1.5
+    - hedgehog >= 1.0.3 && < 1.8
     - hspec
     - hspec-hedgehog
     - http-client

--- a/src/AWS/Lambda/Events/Kafka.hs
+++ b/src/AWS/Lambda/Events/Kafka.hs
@@ -174,10 +174,15 @@ instance FromJSON (Record' ByteString) where
     partition <- o .: "partition"
     offset <- o .: "offset"
     timestamp <- parseTimestamp o
-    headers <- o .: "headers"
+    headers <- o .: "headers" >>= fmap catMaybes . traverse parseNullableHeader
     key <- fmap (B64.decodeLenient . TE.encodeUtf8) <$> o .:? "key"
     value <- fmap (B64.decodeLenient . TE.encodeUtf8) <$> o .:? "value"
     pure Record { topic, partition, offset, timestamp, headers, key, value }
+    where
+      -- AWS serialises Kafka headers with null values as {}, which has no
+      -- key to extract. Skip these rather than failing.
+      parseNullableHeader (Object o) | KM.null o = pure Nothing
+      parseNullableHeader v                       = Just <$> parseJSON v
 
 -- | Encodes keys and values into base64.
 instance ToJSON (Record' ByteString) where

--- a/src/AWS/Lambda/Events/SQS.hs
+++ b/src/AWS/Lambda/Events/SQS.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
 {-|
 Module      : AWS.Lambda.Events.SQS
 Description : Data types for working with SQS events.
@@ -18,9 +21,13 @@ import Data.Map     (Map)
 import Data.Text    (Text)
 import GHC.Generics (Generic)
 
+-- | Represents an event from AWS SQS.
+--
+-- See the <https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html AWS documentation>
+-- for a sample payload.
 newtype Records = Records {
   records :: [SQSEvent]
-} deriving (Show, Eq)
+} deriving (Show, Eq, Generic)
 
 instance FromJSON Records where
   parseJSON = withObject "Records" $ \v -> Records <$> v .: "Records"
@@ -29,16 +36,18 @@ data Attributes = Attributes {
   approximateReceiveCount          :: Text,
   sentTimestamp                    :: Text,
   senderId                         :: Text,
-  approximateFirstReceiveTimestamp :: Text
-} deriving (Show, Eq)
+  approximateFirstReceiveTimestamp :: Text,
+  messageGroupId                   :: Text
+} deriving (Show, Eq, Generic)
 
 instance FromJSON Attributes where
-  parseJSON = withObject "Attributes" $ \v ->
-    Attributes
-      <$> v .: "ApproximateReceiveCount"
-      <*> v .: "SentTimestamp"
-      <*> v .: "SenderId"
-      <*> v .: "ApproximateFirstReceiveTimestamp"
+  parseJSON = withObject "Attributes" $ \v -> do
+    approximateReceiveCount <- v .: "ApproximateReceiveCount"
+    sentTimestamp <- v .: "SentTimestamp"
+    senderId <- v .: "SenderId"
+    approximateFirstReceiveTimestamp <- v .: "ApproximateFirstReceiveTimestamp"
+    messageGroupId <- v .: "MessageGroupId"
+    pure Attributes {..}
 
 data SQSEvent = SQSEvent {
   messageId         :: Text,

--- a/src/AWS/Lambda/Events/SQS.hs
+++ b/src/AWS/Lambda/Events/SQS.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE ApplicativeDo   #-}
 {-# LANGUAGE RecordWildCards #-}
 
 {-|
@@ -13,13 +13,17 @@ Stability   : stable
 module AWS.Lambda.Events.SQS (
   Records (..),
   Attributes (..),
+  MessageAttributeValue (..),
   SQSEvent (..)
 ) where
 
-import Data.Aeson   (FromJSON (..), withObject, (.:), (.:?))
-import Data.Map     (Map)
-import Data.Text    (Text)
-import GHC.Generics (Generic)
+import           Data.Aeson             (FromJSON (..), withObject, (.:), (.:?))
+import           Data.ByteString        (ByteString)
+import qualified Data.ByteString.Base64 as B64
+import           Data.Map               (Map)
+import           Data.Text              (Text)
+import qualified Data.Text.Encoding     as TE
+import           GHC.Generics           (Generic)
 
 -- | Represents an event from AWS SQS.
 --
@@ -49,12 +53,29 @@ instance FromJSON Attributes where
     messageGroupId <- v .:? "MessageGroupId"
     pure Attributes {..}
 
+data MessageAttributeValue = MessageAttributeValue {
+  stringValue      :: Maybe Text,
+  binaryValue      :: Maybe ByteString,
+  stringListValues :: [Text],
+  binaryListValues :: [ByteString],
+  dataType         :: Text
+} deriving (Show, Eq, Generic)
+
+instance FromJSON MessageAttributeValue where
+  parseJSON = withObject "MessageAttributeValue" $ \v -> do
+    stringValue <- v .:? "stringValue"
+    binaryValue <- fmap decodeBase64Text <$> v .:? "binaryValue"
+    stringListValues <- maybe [] id <$> v .:? "stringListValues"
+    binaryListValues <- maybe [] (map decodeBase64Text) <$> v .:? "binaryListValues"
+    dataType <- v .: "dataType"
+    pure MessageAttributeValue {..}
+
 data SQSEvent = SQSEvent {
   messageId         :: Text,
   receiptHandle     :: Text,
   body              :: Text,
   attributes        :: Attributes,
-  messageAttributes :: Map Text Text,
+  messageAttributes :: Map Text MessageAttributeValue,
   md5OfBody         :: Text,
   eventSource       :: Text,
   eventSourceARN    :: Text,
@@ -62,3 +83,6 @@ data SQSEvent = SQSEvent {
 } deriving (Show, Eq, Generic)
 
 instance FromJSON SQSEvent
+
+decodeBase64Text :: Text -> ByteString
+decodeBase64Text = B64.decodeLenient . TE.encodeUtf8

--- a/src/AWS/Lambda/Events/SQS.hs
+++ b/src/AWS/Lambda/Events/SQS.hs
@@ -53,6 +53,10 @@ instance FromJSON Attributes where
     messageGroupId <- v .:? "MessageGroupId"
     pure Attributes {..}
 
+-- | An SQS message attribute value as it appears in Lambda SQS event payloads.
+--
+-- See the <https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#example-standard-queue-message-event AWS Lambda SQS event payload example>
+-- for the JSON shape used under @messageAttributes@.
 data MessageAttributeValue = MessageAttributeValue {
   stringValue      :: Maybe Text,
   binaryValue      :: Maybe ByteString,

--- a/src/AWS/Lambda/Events/SQS.hs
+++ b/src/AWS/Lambda/Events/SQS.hs
@@ -16,7 +16,7 @@ module AWS.Lambda.Events.SQS (
   SQSEvent (..)
 ) where
 
-import Data.Aeson   (FromJSON (..), withObject, (.:))
+import Data.Aeson   (FromJSON (..), withObject, (.:), (.:?))
 import Data.Map     (Map)
 import Data.Text    (Text)
 import GHC.Generics (Generic)
@@ -37,7 +37,7 @@ data Attributes = Attributes {
   sentTimestamp                    :: Text,
   senderId                         :: Text,
   approximateFirstReceiveTimestamp :: Text,
-  messageGroupId                   :: Text
+  messageGroupId                   :: Maybe Text
 } deriving (Show, Eq, Generic)
 
 instance FromJSON Attributes where
@@ -46,7 +46,7 @@ instance FromJSON Attributes where
     sentTimestamp <- v .: "SentTimestamp"
     senderId <- v .: "SenderId"
     approximateFirstReceiveTimestamp <- v .: "ApproximateFirstReceiveTimestamp"
-    messageGroupId <- v .: "MessageGroupId"
+    messageGroupId <- v .:? "MessageGroupId"
     pure Attributes {..}
 
 data SQSEvent = SQSEvent {

--- a/src/AWS/Lambda/Events/SQS.hs
+++ b/src/AWS/Lambda/Events/SQS.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo   #-}
+{-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}
 
 {-|
@@ -13,6 +14,7 @@ Stability   : stable
 module AWS.Lambda.Events.SQS (
   Records (..),
   Attributes (..),
+  MessageAttribute (..),
   MessageAttributeValue (..),
   SQSEvent (..)
 ) where
@@ -21,9 +23,12 @@ import           Data.Aeson             (FromJSON (..), withObject, (.:), (.:?))
 import           Data.ByteString        (ByteString)
 import qualified Data.ByteString.Base64 as B64
 import           Data.Map               (Map)
+import           Data.Scientific        (Scientific)
 import           Data.Text              (Text)
+import qualified Data.Text              as Text
 import qualified Data.Text.Encoding     as TE
 import           GHC.Generics           (Generic)
+import           Text.Read              (readMaybe)
 
 -- | Represents an event from AWS SQS.
 --
@@ -53,33 +58,42 @@ instance FromJSON Attributes where
     messageGroupId <- v .:? "MessageGroupId"
     pure Attributes {..}
 
--- | An SQS message attribute value as it appears in Lambda SQS event payloads.
+-- | An SQS message attribute as it appears in Lambda SQS event payloads.
 --
 -- See the <https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#example-standard-queue-message-event AWS Lambda SQS event payload example>
 -- for the JSON shape used under @messageAttributes@.
-data MessageAttributeValue = MessageAttributeValue {
-  stringValue      :: Maybe Text,
-  binaryValue      :: Maybe ByteString,
-  stringListValues :: [Text],
-  binaryListValues :: [ByteString],
-  dataType         :: Text
+data MessageAttribute = MessageAttribute {
+  customTypeLabel :: Maybe Text,
+  value           :: MessageAttributeValue
 } deriving (Show, Eq, Generic)
 
-instance FromJSON MessageAttributeValue where
-  parseJSON = withObject "MessageAttributeValue" $ \v -> do
-    stringValue <- v .:? "stringValue"
-    binaryValue <- fmap decodeBase64Text <$> v .:? "binaryValue"
-    stringListValues <- maybe [] id <$> v .:? "stringListValues"
-    binaryListValues <- maybe [] (map decodeBase64Text) <$> v .:? "binaryListValues"
+instance FromJSON MessageAttribute where
+  parseJSON = withObject "MessageAttribute" $ \v -> do
     dataType <- v .: "dataType"
-    pure MessageAttributeValue {..}
+    let (baseType, customTypeLabel) = splitDataType dataType
+
+    value <- case baseType of
+      "Binary" -> Binary . decodeBase64Text <$> v .: "binaryValue"
+      "Number" -> Number <$> (v .: "stringValue" >>= parseNumber)
+      "String" -> String <$> v .: "stringValue"
+      _ -> fail $ "Unexpected message attribute dataType: " <> show dataType
+
+    pure MessageAttribute { customTypeLabel, value }
+    where
+      parseNumber = maybe (fail "can't parse stringValue into Scientific") pure . readMaybe
+
+data MessageAttributeValue
+  = Binary ByteString
+  | Number Scientific
+  | String Text
+  deriving (Show, Eq, Generic)
 
 data SQSEvent = SQSEvent {
   messageId         :: Text,
   receiptHandle     :: Text,
   body              :: Text,
   attributes        :: Attributes,
-  messageAttributes :: Map Text MessageAttributeValue,
+  messageAttributes :: Map Text MessageAttribute,
   md5OfBody         :: Text,
   eventSource       :: Text,
   eventSourceARN    :: Text,
@@ -90,3 +104,10 @@ instance FromJSON SQSEvent
 
 decodeBase64Text :: Text -> ByteString
 decodeBase64Text = B64.decodeLenient . TE.encodeUtf8
+
+splitDataType :: Text -> (Text, Maybe Text)
+splitDataType dataType =
+  case Text.breakOn "." dataType of
+    (baseType, "") -> (baseType, Nothing)
+    (baseType, customTypeLabel) ->
+      (baseType, Just $ Text.drop 1 customTypeLabel)

--- a/test/AWS/Lambda/Events/SQS/Spec.hs
+++ b/test/AWS/Lambda/Events/SQS/Spec.hs
@@ -4,15 +4,19 @@ module AWS.Lambda.Events.SQS.Spec where
 
 import           AWS.Lambda.Events.SQS
 import           Data.Aeson            (eitherDecode)
+import           Data.Either           (isLeft)
 import qualified Data.Map              as M
 import           Data.ByteString.Lazy  (ByteString)
-import           Test.Hspec            (Spec, shouldBe, specify)
+import           Test.Hspec            (Spec, shouldBe, shouldSatisfy, specify)
 import           Text.RawString.QQ     (r)
 
 spec :: Spec
-spec =
+spec = do
   specify "read sample payload" $
     eitherDecode samplePayload `shouldBe` Right expectedRecords
+
+  specify "fail on invalid number message attributes" $
+    (eitherDecode invalidNumberPayload :: Either String Records) `shouldSatisfy` isLeft
 
 samplePayload :: ByteString
 samplePayload = [r|
@@ -32,15 +36,29 @@ samplePayload = [r|
       "messageAttributes": {
         "attribute1": {
           "stringValue": "value1",
-          "stringListValues": [],
-          "binaryListValues": [],
+          "stringListValues": ["ignored-string-list-value"],
+          "binaryListValues": ["aWdub3JlZC1iaW5hcnktbGlzdC12YWx1ZQ=="],
           "dataType": "String"
         },
         "attribute2": {
+          "stringValue": "ignored-string-value",
           "binaryValue": "dmFsdWUy",
           "stringListValues": [],
           "binaryListValues": [],
           "dataType": "Binary"
+        },
+        "attribute3": {
+          "stringValue": "123.45",
+          "stringListValues": [],
+          "binaryListValues": [],
+          "dataType": "Number"
+        },
+        "attribute4": {
+          "stringValue": "value4",
+          "binaryValue": "aWdub3JlZC1iaW5hcnktdmFsdWU=",
+          "stringListValues": ["ignored-extra-string"],
+          "binaryListValues": ["aWdub3JlZC1leHRyYS1iaW5hcnk="],
+          "dataType": "String.foo"
         }
       },
       "md5OfBody": "9a0364b9e99bb480dd25e1f0284c8555",
@@ -68,21 +86,27 @@ expectedRecords = Records
               }
           , messageAttributes = M.fromList
               [ ( "attribute1"
-                , MessageAttributeValue
-                    { stringValue = Just "value1"
-                    , binaryValue = Nothing
-                    , stringListValues = []
-                    , binaryListValues = []
-                    , dataType = "String"
+                , MessageAttribute
+                    { customTypeLabel = Nothing
+                    , value = String "value1"
                     }
                 )
               , ( "attribute2"
-                , MessageAttributeValue
-                    { stringValue = Nothing
-                    , binaryValue = Just "value2"
-                    , stringListValues = []
-                    , binaryListValues = []
-                    , dataType = "Binary"
+                , MessageAttribute
+                    { customTypeLabel = Nothing
+                    , value = Binary "value2"
+                    }
+                )
+              , ( "attribute3"
+                , MessageAttribute
+                    { customTypeLabel = Nothing
+                    , value = Number 123.45
+                    }
+                )
+              , ( "attribute4"
+                , MessageAttribute
+                    { customTypeLabel = Just "foo"
+                    , value = String "value4"
                     }
                 )
               ]
@@ -93,3 +117,32 @@ expectedRecords = Records
           }
       ]
   }
+
+invalidNumberPayload :: ByteString
+invalidNumberPayload = [r|
+{
+  "Records": [
+    {
+      "messageId": "11111111-2222-3333-4444-555555555555",
+      "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+      "body": "Hello from SQS!",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {
+        "attribute1": {
+          "stringValue": "not-a-number",
+          "dataType": "Number"
+        }
+      },
+      "md5OfBody": "9a0364b9e99bb480dd25e1f0284c8555",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:queue1",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}
+|]

--- a/test/AWS/Lambda/Events/SQS/Spec.hs
+++ b/test/AWS/Lambda/Events/SQS/Spec.hs
@@ -30,8 +30,18 @@ samplePayload = [r|
         "MessageGroupId": "group-1"
       },
       "messageAttributes": {
-        "attribute1": "value1",
-        "attribute2": "value2"
+        "attribute1": {
+          "stringValue": "value1",
+          "stringListValues": [],
+          "binaryListValues": [],
+          "dataType": "String"
+        },
+        "attribute2": {
+          "binaryValue": "dmFsdWUy",
+          "stringListValues": [],
+          "binaryListValues": [],
+          "dataType": "Binary"
+        }
       },
       "md5OfBody": "9a0364b9e99bb480dd25e1f0284c8555",
       "eventSource": "aws:sqs",
@@ -57,8 +67,24 @@ expectedRecords = Records
               , messageGroupId = Just "group-1"
               }
           , messageAttributes = M.fromList
-              [ ("attribute1", "value1")
-              , ("attribute2", "value2")
+              [ ( "attribute1"
+                , MessageAttributeValue
+                    { stringValue = Just "value1"
+                    , binaryValue = Nothing
+                    , stringListValues = []
+                    , binaryListValues = []
+                    , dataType = "String"
+                    }
+                )
+              , ( "attribute2"
+                , MessageAttributeValue
+                    { stringValue = Nothing
+                    , binaryValue = Just "value2"
+                    , stringListValues = []
+                    , binaryListValues = []
+                    , dataType = "Binary"
+                    }
+                )
               ]
           , md5OfBody = "9a0364b9e99bb480dd25e1f0284c8555"
           , eventSource = "aws:sqs"

--- a/test/AWS/Lambda/Events/SQS/Spec.hs
+++ b/test/AWS/Lambda/Events/SQS/Spec.hs
@@ -54,7 +54,7 @@ expectedRecords = Records
               , sentTimestamp = "1523232000000"
               , senderId = "123456789012"
               , approximateFirstReceiveTimestamp = "1523232000001"
-              , messageGroupId = "group-1"
+              , messageGroupId = Just "group-1"
               }
           , messageAttributes = M.fromList
               [ ("attribute1", "value1")

--- a/test/AWS/Lambda/Events/SQS/Spec.hs
+++ b/test/AWS/Lambda/Events/SQS/Spec.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module AWS.Lambda.Events.SQS.Spec where
+
+import           AWS.Lambda.Events.SQS
+import           Data.Aeson            (eitherDecode)
+import qualified Data.Map              as M
+import           Data.ByteString.Lazy  (ByteString)
+import           Test.Hspec            (Spec, shouldBe, specify)
+import           Text.RawString.QQ     (r)
+
+spec :: Spec
+spec =
+  specify "read sample payload" $
+    eitherDecode samplePayload `shouldBe` Right expectedRecords
+
+samplePayload :: ByteString
+samplePayload = [r|
+{
+  "Records": [
+    {
+      "messageId": "11111111-2222-3333-4444-555555555555",
+      "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+      "body": "Hello from SQS!",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001",
+        "MessageGroupId": "group-1"
+      },
+      "messageAttributes": {
+        "attribute1": "value1",
+        "attribute2": "value2"
+      },
+      "md5OfBody": "9a0364b9e99bb480dd25e1f0284c8555",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:queue1",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}
+|]
+
+expectedRecords :: Records
+expectedRecords = Records
+  { records =
+      [ SQSEvent
+          { messageId = "11111111-2222-3333-4444-555555555555"
+          , receiptHandle = "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a..."
+          , body = "Hello from SQS!"
+          , attributes = Attributes
+              { approximateReceiveCount = "1"
+              , sentTimestamp = "1523232000000"
+              , senderId = "123456789012"
+              , approximateFirstReceiveTimestamp = "1523232000001"
+              , messageGroupId = "group-1"
+              }
+          , messageAttributes = M.fromList
+              [ ("attribute1", "value1")
+              , ("attribute2", "value2")
+              ]
+          , md5OfBody = "9a0364b9e99bb480dd25e1f0284c8555"
+          , eventSource = "aws:sqs"
+          , eventSourceARN = "arn:aws:sqs:us-east-1:123456789012:queue1"
+          , awsRegion = "us-east-1"
+          }
+      ]
+  }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified AWS.Lambda.Events.ApiGateway.ProxyResponse.Spec as ProxyRespons
 
 import qualified AWS.Lambda.Events.EventBridge.Spec as EventBridge
 import qualified AWS.Lambda.Events.Kafka.Spec       as Kafka
+import qualified AWS.Lambda.Events.SQS.Spec         as SQS
 import           AWS.Lambda.Internal                (StaticContext (..))
 import           AWS.Lambda.RuntimeClient.Internal  (eventResponseToNextData)
 import           Data.Aeson                         (Value (Null))
@@ -37,6 +38,7 @@ main =
         describe "ProxyResponse" ProxyResponse.spec
       describe "EventBridge" EventBridge.spec
       describe "Kafka" Kafka.spec
+      describe "SQS" SQS.spec
 
     describe "Event Response Data" $ do
       let staticContext =


### PR DESCRIPTION
Based on #139. The diff will be more clear once #139 is merged.

The current type of `messageAttributes` in `SQSEvent` is not correct. It shouldn't be `Map Text Text`. This PR adds a new `MessageAttributeValue` type similar to [amazonka's version](https://github.com/brendanhay/amazonka/blob/main/lib/services/amazonka-sqs/gen/Amazonka/SQS/Types/MessageAttributeValue.hs).
