### PR TITLE
Support newer releases of `hedgehog` and drop aeson migration flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][chg] and this project adheres to
 [Haskell's Package Versioning Policy][pvp]
 
+## `1.2` - 2026-??-??
+
+  - The `use-aeson-2.2` flag has been removed.
+
 ## `1.1` - 2023-12-18
 
   - `fallibleRuntime` and `fallibleRuntimeWithContext` report errors to AWS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog][chg] and this project adheres to
 
 ## Unreleased
   - Add `messageGroupId` to SQS Attributes.
-  - Fix header parsing to accept `null` values serialised as `{}` 
+  - Fix header parsing to accept `null` values serialised as `{}`
+  - The `use-aeson-2.2` flag has been removed in favour of a
+    dependency on the `attoparsec-aeson` compatibility package.
 
 ## `1.1` - 2023-12-18
 

--- a/hal.cabal
+++ b/hal.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 68071e7a76bb7ee4441cd578bc9de2a1c3ffb2622ab059ce676d816922ed3d4b
+-- hash: 7d2b383d5d9e18970386660420500cc1f0ca2854bd5d44259e9bd962bf82a63d
 
 name:           hal
 version:        1.1
@@ -28,11 +28,6 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/Nike-inc/hal
-
-flag use-aeson-2-2
-  description: Required parsers are split out into a different package
-  manual: False
-  default: True
 
 library
   exposed-modules:
@@ -76,7 +71,9 @@ library
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
-      base >=4.7 && <5
+      aeson >=1.4.1.0 && <2.3
+    , attoparsec-aeson >=2.1.0.0 && <2.3
+    , base >=4.7 && <5
     , base64-bytestring
     , bytestring
     , case-insensitive
@@ -93,13 +90,6 @@ library
     , time
     , unordered-containers
   default-language: Haskell2010
-  if flag(use-aeson-2-2)
-    build-depends:
-        aeson >=2.2.0.0 && <2.3.0.0
-      , attoparsec-aeson
-  else
-    build-depends:
-        aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
 
 test-suite hal-test
   type: exitcode-stdio-1.0
@@ -149,7 +139,7 @@ test-suite hal-test
     , case-insensitive
     , containers
     , hal
-    , hedgehog >=1.0.3 && <1.5
+    , hedgehog >=1.0.3 && <1.8
     , hspec
     , hspec-hedgehog
     , http-client

--- a/hal.cabal
+++ b/hal.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: a8f1e61978a7c0772b00f7d79b8d54b83646f1aac9da8e964f32057442567c95
 
 name:           hal
 version:        1.1
@@ -28,11 +26,6 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/Nike-inc/hal
-
-flag use-aeson-2-2
-  description: Required parsers are split out into a different package
-  manual: False
-  default: True
 
 library
   exposed-modules:
@@ -76,7 +69,9 @@ library
       ScopedTypeVariables
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
-      base >=4.7 && <5
+      aeson >=1.4.1.0 && <2.3
+    , attoparsec-aeson >=2.1.0.0 && <2.3
+    , base >=4.7 && <5
     , base64-bytestring
     , bytestring
     , case-insensitive
@@ -93,13 +88,6 @@ library
     , time
     , unordered-containers
   default-language: Haskell2010
-  if flag(use-aeson-2-2)
-    build-depends:
-        aeson >=2.2.0.0 && <2.3.0.0
-      , attoparsec-aeson
-  else
-    build-depends:
-        aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
 
 test-suite hal-test
   type: exitcode-stdio-1.0

--- a/package.yaml
+++ b/package.yaml
@@ -52,15 +52,11 @@ ghc-options:
   - -fwarn-missing-signatures
   - -fwarn-incomplete-patterns
 
-flags:
-  use-aeson-2-2:
-    description: Required parsers are split out into a different package
-    default: true
-    manual: false
-
 library:
   source-dirs: src
   dependencies:
+    - aeson >=1.4.1.0 && <2.3
+    - attoparsec-aeson >=2.1.0.0 && <2.3
     - base64-bytestring
     - bytestring
     - case-insensitive
@@ -76,15 +72,6 @@ library:
     - text
     - time
     - unordered-containers
-  when:
-    - condition: flag(use-aeson-2-2)
-      then:
-        dependencies:
-          - aeson >=2.2.0.0 && <2.3.0.0
-          - attoparsec-aeson
-      else:
-        dependencies:
-          - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
 
 tests:
   hal-test:
@@ -101,7 +88,7 @@ tests:
     - bytestring
     - case-insensitive
     - containers
-    - hedgehog >= 1.0.3 && < 1.5
+    - hedgehog >= 1.0.3 && < 1.8
     - hspec
     - hspec-hedgehog
     - http-client

--- a/package.yaml
+++ b/package.yaml
@@ -52,15 +52,11 @@ ghc-options:
   - -fwarn-missing-signatures
   - -fwarn-incomplete-patterns
 
-flags:
-  use-aeson-2-2:
-    description: Required parsers are split out into a different package
-    default: true
-    manual: false
-
 library:
   source-dirs: src
   dependencies:
+    - aeson >=1.4.1.0 && <2.3
+    - attoparsec-aeson >=2.1.0.0 && <2.3
     - base64-bytestring
     - bytestring
     - case-insensitive
@@ -76,15 +72,6 @@ library:
     - text
     - time
     - unordered-containers
-  when:
-    - condition: flag(use-aeson-2-2)
-      then:
-        dependencies:
-          - aeson >=2.2.0.0 && <2.3.0.0
-          - attoparsec-aeson
-      else:
-        dependencies:
-          - aeson >=1.2.0.0 && <1.6 || >=2.0.0.0 && <2.2.0.0
 
 tests:
   hal-test:

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,10 +1,8 @@
 resolver: lts-13
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
 extra-deps:
+- attoparsec-aeson-2.1.0.0
 - hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - hspec-2.7.1@sha256:0aa48928ce80a34f8ff8c5ef114bb6807edfb8d884bcd7211eceed710e7fb7a8,1769
 - hspec-core-2.7.1@sha256:ead64b6d552e477549624fc9de3658657faac0dabf7109f889d595be05547bbf,4594

--- a/stack-lts-14.yaml
+++ b/stack-lts-14.yaml
@@ -1,9 +1,7 @@
 resolver: lts-14
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
 extra-deps:
+- attoparsec-aeson-2.1.0.0
 - hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - hspec-hedgehog-0.0.1.2@sha256:4d09c7be34cdc941b78e4e964f71013ffeeb099ea32d8ede17ad9c03ae7a62e3,1470

--- a/stack-lts-15.yaml
+++ b/stack-lts-15.yaml
@@ -1,9 +1,7 @@
 resolver: lts-15
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
 extra-deps:
+- attoparsec-aeson-2.1.0.0
 - hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - hspec-hedgehog-0.0.1.2@sha256:4d09c7be34cdc941b78e4e964f71013ffeeb099ea32d8ede17ad9c03ae7a62e3,1470

--- a/stack-lts-16.yaml
+++ b/stack-lts-16.yaml
@@ -1,6 +1,5 @@
 resolver: lts-16
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
+extra-deps:
+- attoparsec-aeson-2.1.0.0

--- a/stack-lts-17.yaml
+++ b/stack-lts-17.yaml
@@ -1,6 +1,5 @@
 resolver: lts-17
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
+extra-deps:
+- attoparsec-aeson-2.1.0.0

--- a/stack-lts-18.yaml
+++ b/stack-lts-18.yaml
@@ -1,6 +1,5 @@
 resolver: lts-18
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
+extra-deps:
+- attoparsec-aeson-2.1.0.0

--- a/stack-lts-19.yaml
+++ b/stack-lts-19.yaml
@@ -1,6 +1,5 @@
 resolver: lts-19
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
+extra-deps:
+- attoparsec-aeson-2.1.0.0

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -1,6 +1,5 @@
 resolver: lts-20
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false
+extra-deps:
+- attoparsec-aeson-2.1.0.0

--- a/stack-lts-21.yaml
+++ b/stack-lts-21.yaml
@@ -1,6 +1,3 @@
 resolver: lts-21
 packages:
 - .
-flags:
-  hal:
-    use-aeson-2-2: false


### PR DESCRIPTION
NOTE: `attoparsec-aeson` has a shim `2.1.0.0` release that depends on old versions of `aeson`, ensuring that `Data.Aeson.Parser` is always available.

This would also allow the package to be unmarked `broken` in nixpkgs, which currently uses `hedgehog-1.5` that `hal` currently excludes.