### PR TITLE
Bump Github Action action/cache version

### DIFF
--- a/.github/workflows/haskell_cabal.yaml
+++ b/.github/workflows/haskell_cabal.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cabal/packages

--- a/.github/workflows/haskell_stack.yaml
+++ b/.github/workflows/haskell_stack.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.stack

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.stack


### PR DESCRIPTION
Moved from v2, now hard dropped, to v4.