### PR TITLE
Fix cache key error for Github Action Cabal builds

### DIFF
--- a/.github/workflows/haskell_cabal.yaml
+++ b/.github/workflows/haskell_cabal.yaml
@@ -35,7 +35,10 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ matrix.plan.ghc-version }}
+          key: ${{ matrix.plan.ghc-version }}-${{ hashFiles('hal.cabal') }}
+          # Still use a reasonable warm start on a miss
+          restore-keys: |
+            ${{ matrix.plan.ghc-version }}-
       - name: Install Cabal
         uses: haskell/actions/setup@v1
         with:


### PR DESCRIPTION
Since we didn't consider the cabal file in our cache key, just the GHC version, we could get incorrect cache collisions.